### PR TITLE
Add tree-sitter rust extractors for use, calls, and trait impls

### DIFF
--- a/src/kindex/adapters/code.py
+++ b/src/kindex/adapters/code.py
@@ -520,50 +520,199 @@ def _ts_extract_imports_python(tree: Any, source: bytes) -> list[tuple[str, str]
     return results
 
 
+def _ts_extract_imports_rust(tree: Any, source: bytes) -> list[tuple[str, str]]:
+    """Extract Rust imports from tree-sitter AST.
+
+    Parses ``use`` declarations and returns ``(local_name, module_path)``
+    pairs, using ``::`` separators for module paths to mirror Rust's own
+    syntax. Handles:
+
+      - ``use foo;``                     → ("foo", "foo")
+      - ``use foo::bar;``                → ("bar", "foo::bar")
+      - ``use foo::{bar, baz};``         → ("bar", "foo::bar"), ("baz", "foo::baz")
+      - ``use foo::bar as b;``           → ("b", "foo::bar")
+      - ``use foo::*;``                  → ("*", "foo")  (glob)
+      - ``use crate::foo;``              → ("foo", "crate::foo")
+
+    Module-level only — does not descend into ``mod {}`` blocks.
+    """
+    results: list[tuple[str, str]] = []
+    root = tree.root_node
+
+    def _text(n: Any) -> str:
+        return source[n.start_byte:n.end_byte].decode(errors="replace")
+
+    def _expand_use_tree(node: Any, prefix: str) -> None:
+        """Expand a ``use`` tree node into (local_name, full_path) pairs.
+
+        ``prefix`` is the dotted-but-Rust-style scope already accumulated
+        (e.g. "foo::bar" when processing the contents of a use_list).
+        """
+        kind = node.type
+        if kind == "identifier":
+            name = _text(node)
+            full = f"{prefix}::{name}" if prefix else name
+            results.append((name, full))
+        elif kind == "scoped_identifier":
+            full = _text(node)
+            full = f"{prefix}::{full}" if prefix else full
+            local = full.rsplit("::", 1)[-1]
+            results.append((local, full))
+        elif kind == "scoped_use_list":
+            # foo::{bar, baz}  — first child is the scope, then the use_list
+            scope_node = node.child_by_field_name("path")
+            list_node = node.child_by_field_name("list")
+            scope = _text(scope_node) if scope_node else ""
+            new_prefix = f"{prefix}::{scope}" if prefix and scope else (scope or prefix)
+            if list_node:
+                for child in list_node.children:
+                    if child.type not in (",", "{", "}"):
+                        _expand_use_tree(child, new_prefix)
+        elif kind == "use_list":
+            for child in node.children:
+                if child.type not in (",", "{", "}"):
+                    _expand_use_tree(child, prefix)
+        elif kind == "use_as_clause":
+            path_node = node.child_by_field_name("path")
+            alias_node = node.child_by_field_name("alias")
+            if path_node:
+                full = _text(path_node)
+                full = f"{prefix}::{full}" if prefix else full
+                local = _text(alias_node) if alias_node else full.rsplit("::", 1)[-1]
+                results.append((local, full))
+        elif kind == "use_wildcard":
+            # foo::* — the glob import. Record under the scope path.
+            for child in node.children:
+                if child.type in ("identifier", "scoped_identifier"):
+                    base = _text(child)
+                    full = f"{prefix}::{base}" if prefix else base
+                    results.append(("*", full))
+                    return
+            if prefix:
+                results.append(("*", prefix))
+
+    def _walk(node: Any) -> None:
+        if node.type == "use_declaration":
+            # First non-trivial child after the `use` keyword is the tree.
+            for child in node.children:
+                if child.type in (
+                    "identifier", "scoped_identifier", "scoped_use_list",
+                    "use_list", "use_as_clause", "use_wildcard",
+                ):
+                    _expand_use_tree(child, "")
+                    break
+        else:
+            for child in node.children:
+                _walk(child)
+
+    _walk(root)
+    return results
+
+
+def _ts_extract_trait_impls_rust(tree: Any, source: bytes) -> list[tuple[str, str]]:
+    """Extract Rust trait implementations from tree-sitter AST.
+
+    Returns ``(implementing_type, trait_name)`` pairs for every
+    ``impl Trait for Type`` block. Inherent impls (``impl Type {}``)
+    are skipped — they have no trait, so they produce no edge.
+
+    Universal-ctags does not surface trait names in its ``inherits``
+    field for Rust impl blocks (verified empirically), so this is the
+    only path for Rust trait-impl edges in the graph.
+    """
+    results: list[tuple[str, str]] = []
+    root = tree.root_node
+
+    def _text(n: Any) -> str:
+        return source[n.start_byte:n.end_byte].decode(errors="replace")
+
+    def _walk(node: Any) -> None:
+        if node.type == "impl_item":
+            trait_node = node.child_by_field_name("trait")
+            type_node = node.child_by_field_name("type")
+            if trait_node and type_node:
+                trait_name = _text(trait_node)
+                impl_type = _text(type_node)
+                # Strip generic parameters: `Display<T>` → `Display`,
+                # `Vec<u8>` → `Vec`. Keeps the symbol-name match simple.
+                trait_name = trait_name.split("<", 1)[0].split("::")[-1]
+                impl_type = impl_type.split("<", 1)[0].split("::")[-1]
+                if trait_name and impl_type:
+                    results.append((impl_type, trait_name))
+        for child in node.children:
+            _walk(child)
+
+    _walk(root)
+    return results
+
+
 def _ts_extract_calls(tree: Any, source: bytes) -> list[tuple[str, str]]:
     """Extract function calls from tree-sitter AST.
 
-    Returns (containing_function, called_function) pairs.
-    Only extracts direct calls within function/method bodies (depth 1).
+    Returns ``(containing_function, called_function)`` pairs. Handles
+    Python (``call`` / ``function_definition`` / ``class_definition``)
+    and Rust (``call_expression`` / ``function_item`` / ``impl_item``).
     """
     results = []
     root = tree.root_node
 
+    # Node-type aliases differ across grammars. Treat both flavors uniformly.
+    CALL_TYPES = {"call", "call_expression"}
+    FN_TYPES = {"function_definition", "method_definition", "function_item"}
+    BODY_TYPES = {"block"}  # function_item carries its body in `block` too
+
     def _find_calls_in_function(func_node: Any, func_name: str) -> None:
         """Walk a function body and find call expressions."""
         for child in func_node.children:
-            if child.type == "block":
+            if child.type in BODY_TYPES:
                 _walk_for_calls(child, func_name)
 
     def _walk_for_calls(node: Any, func_name: str) -> None:
-        if node.type == "call":
-            # Get the function being called
+        if node.type in CALL_TYPES:
             callee = node.child_by_field_name("function")
             if callee:
-                callee_name = source[callee.start_byte:callee.end_byte].decode()
-                # Strip self. prefix for method calls
+                callee_name = source[callee.start_byte:callee.end_byte].decode(
+                    errors="replace",
+                )
+                # Strip self./Self:: prefixes — they're scope, not name.
                 if callee_name.startswith("self."):
                     callee_name = callee_name[5:]
-                # Only keep simple names (foo, bar.baz), skip complex expressions
+                elif callee_name.startswith("Self::"):
+                    callee_name = callee_name[6:]
+                # Only keep simple names; skip complex generic expressions.
                 if callee_name and len(callee_name) < 80:
                     results.append((func_name, callee_name))
         for child in node.children:
             _walk_for_calls(child, func_name)
 
     def _walk_top(node: Any, scope: str = "") -> None:
-        if node.type in ("function_definition", "method_definition"):
+        if node.type in FN_TYPES:
             name_node = node.child_by_field_name("name")
             if name_node:
-                name = source[name_node.start_byte:name_node.end_byte].decode()
+                name = source[name_node.start_byte:name_node.end_byte].decode(
+                    errors="replace",
+                )
                 qualified = f"{scope}.{name}" if scope else name
                 _find_calls_in_function(node, qualified)
         elif node.type == "class_definition":
             name_node = node.child_by_field_name("name")
             cls_name = ""
             if name_node:
-                cls_name = source[name_node.start_byte:name_node.end_byte].decode()
+                cls_name = source[name_node.start_byte:name_node.end_byte].decode(
+                    errors="replace",
+                )
             for child in node.children:
                 _walk_top(child, cls_name)
+        elif node.type == "impl_item":
+            # Rust: methods inside `impl Type { ... }` belong to Type's scope.
+            type_node = node.child_by_field_name("type")
+            impl_scope = ""
+            if type_node:
+                impl_scope = source[
+                    type_node.start_byte:type_node.end_byte
+                ].decode(errors="replace")
+            for child in node.children:
+                _walk_top(child, impl_scope)
         else:
             for child in node.children:
                 _walk_top(child, scope)
@@ -992,15 +1141,87 @@ def ingest_code(
             if not mod_id:
                 continue
 
-            # Import edges from tree-sitter (more accurate than ctags)
+            # Import edges from tree-sitter (more accurate than ctags).
+            # Resolution is per-language because the path syntax differs:
+            # Python uses dotted ("foo.bar"), Rust uses scoped ("foo::bar"
+            # plus crate-relative "crate::*", "super::*", "self::*").
             if language == "Python":
                 ts_imports = _ts_extract_imports_python(tree, source)
                 for local_name, mod_path in ts_imports:
-                    # Try to resolve to a module node
                     target_id = None
                     mod_parts = mod_path.replace(".", "/")
                     for rp, mid in module_node_ids.items():
                         if rp.replace(".py", "").endswith(mod_parts) or Path(rp).stem == local_name:
+                            target_id = mid
+                            break
+                    if target_id and target_id != mod_id:
+                        try:
+                            store.add_edge(
+                                mod_id, target_id,
+                                edge_type="depends_on",
+                                weight=0.5,
+                                provenance=f"code-ingest: imports {mod_path} (tree-sitter)",
+                                bidirectional=False,
+                            )
+                        except Exception:
+                            pass
+            elif language == "Rust":
+                # Trait impl edges (impl Trait for Type → implements).
+                # ctags doesn't surface this in `inherits` for Rust, so
+                # tree-sitter is the only source.
+                for impl_type, trait_name in _ts_extract_trait_impls_rust(
+                    tree, source,
+                ):
+                    # Match the symbol nodes by suffix on qualified name —
+                    # ctags reports symbols as "<rel_path>:<scope>.<name>"
+                    # so we match on the trailing ".<name>" or ":<name>".
+                    impl_id = None
+                    trait_id = None
+                    for qname, sid in symbol_node_ids.items():
+                        leaf = qname.rsplit(".", 1)[-1].rsplit(":", 1)[-1]
+                        if leaf == impl_type and impl_id is None:
+                            impl_id = sid
+                        if leaf == trait_name and trait_id is None:
+                            trait_id = sid
+                    if impl_id and trait_id and impl_id != trait_id:
+                        try:
+                            store.add_edge(
+                                impl_id, trait_id,
+                                edge_type="implements",
+                                weight=0.7,
+                                provenance=(
+                                    f"code-ingest: impl {trait_name} for "
+                                    f"{impl_type} (tree-sitter)"
+                                ),
+                                bidirectional=False,
+                            )
+                        except Exception:
+                            pass
+
+                ts_imports = _ts_extract_imports_rust(tree, source)
+                for local_name, mod_path in ts_imports:
+                    # Strip crate-relative prefixes so the suffix match works:
+                    # crate::foo::bar  → foo::bar  (crate root corresponds to src/)
+                    # self::foo        → foo      (relative to current file's dir)
+                    # super::foo       → foo      (parent module — best-effort)
+                    norm_path = mod_path
+                    for prefix in ("crate::", "self::", "super::"):
+                        if norm_path.startswith(prefix):
+                            norm_path = norm_path[len(prefix):]
+                            break
+                    mod_parts = norm_path.replace("::", "/")
+                    target_id = None
+                    for rp, mid in module_node_ids.items():
+                        rp_stem = rp.replace(".rs", "")
+                        # Match either the full path tail or a leaf name when
+                        # the import resolves to a single symbol (use foo::Bar).
+                        if rp_stem.endswith(mod_parts) or Path(rp).stem == local_name:
+                            target_id = mid
+                            break
+                        # Module hierarchies: `use foo::bar;` may import
+                        # symbols from foo.rs; match the parent path too.
+                        parent = mod_parts.rsplit("/", 1)[0] if "/" in mod_parts else mod_parts
+                        if parent and rp_stem.endswith(parent):
                             target_id = mid
                             break
                     if target_id and target_id != mod_id:

--- a/tests/test_code_adapter_rust.py
+++ b/tests/test_code_adapter_rust.py
@@ -1,0 +1,315 @@
+"""Rust support tests for the kindex code adapter.
+
+Covers the rust-specific tree-sitter extractors and an end-to-end ingestion
+smoke test on a synthetic 3-file rust project.
+"""
+from __future__ import annotations
+
+import importlib.util
+import textwrap
+from pathlib import Path
+
+import pytest
+
+# Skip the module if tree-sitter or the rust grammar isn't installed —
+# kindex does not require either at import time.
+if (
+    importlib.util.find_spec("tree_sitter") is None
+    or importlib.util.find_spec("tree_sitter_rust") is None
+):
+    pytest.skip(
+        "tree-sitter / tree-sitter-rust not installed",
+        allow_module_level=True,
+    )
+
+from kindex.adapters.code import (  # noqa: E402
+    _check_treesitter,
+    _ts_extract_calls,
+    _ts_extract_imports_rust,
+)
+
+
+def _parse(src: str):
+    parser = _check_treesitter("Rust")
+    assert parser is not None, "tree-sitter Rust parser failed to load"
+    source_bytes = src.encode()
+    tree = parser.parse(source_bytes)
+    return tree, source_bytes
+
+
+# ── Imports ────────────────────────────────────────────────────────
+
+
+class TestRustImports:
+    def test_simple_use(self):
+        tree, src = _parse("use std;\nfn main() {}\n")
+        assert ("std", "std") in _ts_extract_imports_rust(tree, src)
+
+    def test_scoped_use(self):
+        tree, src = _parse("use std::collections::HashMap;\n")
+        imports = _ts_extract_imports_rust(tree, src)
+        assert any(
+            local == "HashMap" and "std::collections::HashMap" in path
+            for local, path in imports
+        ), imports
+
+    def test_use_list(self):
+        tree, src = _parse("use std::collections::{HashMap, HashSet};\n")
+        imports = _ts_extract_imports_rust(tree, src)
+        names = {local for local, _ in imports}
+        assert "HashMap" in names
+        assert "HashSet" in names
+        # Both must carry the full scoped path.
+        for local, path in imports:
+            if local in {"HashMap", "HashSet"}:
+                assert path.startswith("std::collections::"), (local, path)
+
+    def test_use_as(self):
+        tree, src = _parse("use std::io::Result as IoResult;\n")
+        imports = _ts_extract_imports_rust(tree, src)
+        assert ("IoResult", "std::io::Result") in imports or any(
+            local == "IoResult" for local, _ in imports
+        ), imports
+
+    def test_use_glob(self):
+        tree, src = _parse("use foo::bar::*;\n")
+        imports = _ts_extract_imports_rust(tree, src)
+        assert any(local == "*" for local, _ in imports), imports
+
+    def test_use_crate_relative(self):
+        tree, src = _parse("use crate::auth::login;\n")
+        imports = _ts_extract_imports_rust(tree, src)
+        assert any(
+            "crate::auth::login" in path for _, path in imports
+        ), imports
+
+    def test_no_use_no_imports(self):
+        tree, src = _parse("fn add(a: i32, b: i32) -> i32 { a + b }\n")
+        assert _ts_extract_imports_rust(tree, src) == []
+
+
+# ── Calls ──────────────────────────────────────────────────────────
+
+
+class TestRustCalls:
+    def test_simple_call(self):
+        tree, src = _parse(textwrap.dedent("""
+            fn helper() {}
+            fn main() {
+                helper();
+            }
+        """).strip() + "\n")
+        calls = _ts_extract_calls(tree, src)
+        assert ("main", "helper") in calls, calls
+
+    def test_method_call_in_impl(self):
+        # Methods inside `impl Type { ... }` belong to Type's scope.
+        tree, src = _parse(textwrap.dedent("""
+            struct Counter { n: i32 }
+
+            impl Counter {
+                fn bump(&mut self) {
+                    self.update(1);
+                }
+                fn update(&mut self, x: i32) { self.n += x; }
+            }
+        """).strip() + "\n")
+        calls = _ts_extract_calls(tree, src)
+        # Counter.bump calls update (self. prefix is stripped).
+        assert ("Counter.bump", "update") in calls, calls
+
+    def test_associated_function_call(self):
+        # `Type::method()` — Self:: prefix is stripped to bare name.
+        tree, src = _parse(textwrap.dedent("""
+            struct Foo;
+            impl Foo {
+                fn new() -> Self { Foo }
+                fn build() -> Self { Self::new() }
+            }
+        """).strip() + "\n")
+        calls = _ts_extract_calls(tree, src)
+        assert ("Foo.build", "new") in calls, calls
+
+    def test_python_calls_still_work(self):
+        # Don't regress python: same helper, different grammar.
+        from kindex.adapters.code import _check_treesitter
+        py_parser = _check_treesitter("Python")
+        if py_parser is None:
+            pytest.skip("tree-sitter-python not installed")
+        py_src = b"def main():\n    helper()\n\ndef helper():\n    pass\n"
+        tree = py_parser.parse(py_src)
+        calls = _ts_extract_calls(tree, py_src)
+        assert ("main", "helper") in calls
+
+
+# ── End-to-end ingestion ──────────────────────────────────────────
+
+
+class TestRustIngestion:
+    """Drive the full code adapter on a synthetic rust crate."""
+
+    def _make_crate(self, root: Path) -> None:
+        """Create a tiny but realistic rust crate under *root*."""
+        src = root / "src"
+        src.mkdir()
+        (src / "lib.rs").write_text(textwrap.dedent("""
+            pub mod auth;
+            pub mod store;
+
+            pub use auth::login;
+        """).lstrip())
+        (src / "auth.rs").write_text(textwrap.dedent("""
+            use crate::store::User;
+
+            pub fn login(user: User) -> bool {
+                user.is_valid()
+            }
+        """).lstrip())
+        (src / "store.rs").write_text(textwrap.dedent("""
+            pub struct User { pub name: String }
+
+            impl User {
+                pub fn is_valid(&self) -> bool {
+                    !self.name.is_empty()
+                }
+            }
+        """).lstrip())
+        # Minimal Cargo.toml so directory is recognizably a crate.
+        (root / "Cargo.toml").write_text(textwrap.dedent("""
+            [package]
+            name = "kindex-test-crate"
+            version = "0.0.1"
+            edition = "2021"
+        """).lstrip())
+
+    def test_ingest_creates_module_nodes(self, tmp_path):
+        from kindex.adapters.code import ingest_code
+        from kindex.config import Config
+        from kindex.store import Store
+
+        crate = tmp_path / "crate"
+        crate.mkdir()
+        self._make_crate(crate)
+
+        cfg = Config(data_dir=str(tmp_path / "kindex"))
+        store = Store(cfg)
+        try:
+            ingest_code(store, crate)
+            # Module nodes use node_type="artifact"; title is the rel path.
+            mods = store.all_nodes(node_type="artifact", limit=200)
+            mod_titles = {m.get("title", "") for m in mods}
+            for expected in ("lib.rs", "auth.rs", "store.rs"):
+                assert any(expected in t for t in mod_titles), (
+                    f"missing module node for {expected}; got {mod_titles}"
+                )
+        finally:
+            store.close()
+
+    def test_ingest_creates_trait_impl_edges(self, tmp_path):
+        """`impl Greet for Greeter` should create an `implements` edge.
+
+        ctags does NOT emit `inherits` for Rust impl blocks (verified
+        empirically), so kindex relies on the tree-sitter-based
+        `_ts_extract_trait_impls_rust` for this — both trait and
+        impl must be locally defined for the edge to be creatable.
+        """
+        from kindex.adapters.code import ingest_code
+        from kindex.config import Config
+        from kindex.store import Store
+
+        crate = tmp_path / "trait-crate"
+        crate.mkdir()
+        (crate / "Cargo.toml").write_text(
+            "[package]\nname = \"trait-test\"\nversion = \"0.0.1\"\n"
+            "edition = \"2021\"\n"
+        )
+        src = crate / "src"
+        src.mkdir()
+        (src / "lib.rs").write_text(textwrap.dedent("""
+            pub trait Greet {
+                fn hello(&self) -> &'static str;
+            }
+
+            pub struct Greeter;
+
+            impl Greet for Greeter {
+                fn hello(&self) -> &'static str { "hi" }
+            }
+        """).lstrip())
+
+        cfg = Config(data_dir=str(tmp_path / "kindex"))
+        store = Store(cfg)
+        try:
+            ingest_code(store, crate)
+            # Whether the implements edge actually appears depends on
+            # whether ctags emits `inherits` for rust impl blocks. If it
+            # doesn't, this test will fail and signal that fix #3 needs
+            # a tree-sitter-based implementation rather than relying on
+            # the generic ctags path.
+            mods = store.all_nodes(node_type="artifact", limit=200)
+            lib = next(
+                (m for m in mods if "lib.rs" in m.get("title", "")), None,
+            )
+            assert lib, "lib.rs module node missing"
+
+            # Look for *any* implements edge originating from a symbol in
+            # this crate. We don't pin a specific from/to id because the
+            # exact ctags output for impl blocks varies by version.
+            symbols = store.all_nodes(node_type="concept", limit=200)
+            crate_symbols = [
+                s for s in symbols
+                if "trait-test" in s.get("id", "")
+                or s.get("id", "").startswith("code-sym-trait")
+            ]
+            implements_edges_found = False
+            for s in crate_symbols:
+                for e in store.edges_from(s["id"]):
+                    if e.get("type") == "implements":
+                        implements_edges_found = True
+                        break
+                if implements_edges_found:
+                    break
+
+            assert implements_edges_found, (
+                "expected an implements edge from Greeter → Greet via "
+                "tree-sitter trait-impl extraction"
+            )
+        finally:
+            store.close()
+
+    def test_ingest_creates_import_edges(self, tmp_path):
+        """auth.rs depends on store.rs via `use crate::store::User`."""
+        from kindex.adapters.code import ingest_code
+        from kindex.config import Config
+        from kindex.store import Store
+
+        crate = tmp_path / "crate"
+        crate.mkdir()
+        self._make_crate(crate)
+
+        cfg = Config(data_dir=str(tmp_path / "kindex"))
+        store = Store(cfg)
+        try:
+            ingest_code(store, crate)
+            mods = store.all_nodes(node_type="artifact", limit=200)
+            auth = next(
+                (m for m in mods if "auth.rs" in m.get("title", "")), None,
+            )
+            store_mod = next(
+                (m for m in mods if "store.rs" in m.get("title", "")), None,
+            )
+            assert auth and store_mod, (
+                f"module nodes missing; titles={[m.get('title') for m in mods]}"
+            )
+
+            edges = store.edges_from(auth["id"])
+            depends_on = [
+                e for e in edges
+                if e.get("type") == "depends_on"
+                and e.get("to_id") == store_mod["id"]
+            ]
+            assert depends_on, (
+                f"expected depends_on edge auth.rs → store.rs; got {edges}"
+            )
+        finally:
+            store.close()


### PR DESCRIPTION
## Summary

Closes the rust support gap in the code adapter. Pre-PR, rust files got ctags-based symbol nodes but **no relationship edges**:

- `use` declarations silently skipped (Phase 5 gated on `language == "Python"`)
- function calls in rust were not extracted (`_ts_extract_calls` only handled python's `call` node type)
- `impl Trait for Type` produced no `implements` edges (ctags does **not** emit `inherits` for rust impl blocks — verified empirically by my test setup)

Three tree-sitter extractors mirror the python pattern:

1. **`_ts_extract_imports_rust(tree, source)`** — parses `use` into `(local_name, module_path)` pairs. Handles `use foo;`, `use foo::bar;`, `use foo::{a, b};`, `use foo::bar as b;`, `use foo::*;`, and crate-/self-/super-relative prefixes.

2. **`_ts_extract_trait_impls_rust(tree, source)`** — walks `impl_item` nodes with a `trait` field; returns `(impl_type, trait_name)` pairs. Strips generic parameters so `Display<T>` matches `Display`.

3. **`_ts_extract_calls(tree, source)` extended** to recognize rust node types (`call_expression`, `function_item`, `impl_item`) so methods inside `impl Type {}` get scoped to `Type`, mirroring python's existing `class_definition` handling. Strips `Self::` in addition to `self.`.

Phase 5 of `ingest_code()` gains a `Rust` branch that creates:
- `depends_on` edges from `use` declarations, with crate-relative resolution
- `implements` edges from `impl Trait for Type`

## Test plan

14 new tests in `tests/test_code_adapter_rust.py`, all passing:
- `_ts_extract_imports_rust` for all six use-statement shapes
- `_ts_extract_calls` for plain calls, method calls in impl blocks, associated function calls (`Self::`), and a regression check that python extraction still works
- end-to-end ingestion on a synthetic 3-file rust crate verifying module nodes, `depends_on` edge from `use crate::*`, and `implements` edge from a locally-defined trait

Module skips cleanly if `tree-sitter-rust` isn't installed (parity with the existing tree-sitter-python pattern).

Full kindex suite: 998 passed, 1 unrelated flake (`test_capture_session_end_with_existing_nodes` — passes in isolation, depends on embedding similarity scores; predates this PR's logic).

## Companion work in pact

A complementary PR in `jmcentire/pact` (#7) makes pact prefer tree-sitter rust symbols over its own regex extractor and pushes `#[test]`-annotated function names to kindex via the existing `query_kindex` integration. Independent of this PR; lands separately.
