### PR TITLE
Use uv tool for MCP server invocation, no pip install required

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -32,5 +32,5 @@
   "requirements": {
     "python": ">=3.10"
   },
-  "install": "pip install kindex[mcp]"
+  "install": "uv tool install 'kindex[mcp]'"
 }

--- a/README.md
+++ b/README.md
@@ -17,12 +17,16 @@ It's a persistent knowledge graph for AI-assisted workflows. It indexes your con
 
 ## Install as Agent MCP Plugin
 
-### Claude Code
-
-Two commands. Zero configuration.
+Requires [`uv`](https://github.com/astral-sh/uv). If you don't have it:
 
 ```bash
-pip install kindex[mcp]
+curl -LsSf https://astral.sh/uv/install.sh | sh
+```
+
+### Claude Code
+
+```bash
+uv tool install 'kindex[mcp]'
 claude mcp add --scope user --transport stdio kindex -- kin-mcp
 kin init
 ```
@@ -36,42 +40,42 @@ Or add `.mcp.json` to any repo for project-scope access:
 
 ### Codex
 
+Add to `~/.codex/config.toml`:
+
+```toml
+[mcp_servers.kindex]
+command = "kin-mcp"
+```
+
+Or automate setup with the `kin` CLI:
+
 ```bash
-pip install kindex[mcp]
+uv tool install 'kindex[mcp]'
 kin init
 kin setup-codex-mcp
 kin setup-agents-md --install --global
-```
-
-This registers `kin-mcp` in `~/.codex/config.toml` and installs Codex-facing
-AGENTS.md directives that tell Codex to use kindex proactively.
-
-To backfill saved Codex sessions:
-
-```bash
-kin ingest codex-sessions
+kin ingest codex-sessions  # optional: backfill saved Codex sessions
 ```
 
 ## Install as CLI
 
 ```bash
-pip install kindex
+uv tool install kindex
 kin init
 ```
 
-With LLM-powered extraction:
+With extras:
 ```bash
-pip install kindex[llm]
+uv tool install 'kindex[llm]'        # LLM-powered extraction
+uv tool install 'kindex[reminders]'  # natural language time parsing
+uv tool install 'kindex[mcp]'        # MCP server (kin-mcp)
+uv tool install 'kindex[all]'        # everything
 ```
 
-With reminders (natural language time parsing):
+Or with pip:
 ```bash
-pip install kindex[reminders]
-```
-
-With everything (LLM + vectors + MCP + reminders):
-```bash
-pip install kindex[all]
+pip install kindex
+kin init
 ```
 
 ## Why Kindex

--- a/docs/index.html
+++ b/docs/index.html
@@ -255,7 +255,7 @@
     </p>
     <div class="install-boxes">
       <div class="install-box primary mono">
-        <span class="prompt">$</span> <code>pip install kindex[mcp]</code>
+        <span class="prompt">$</span> <code>uv tool install 'kindex[mcp]'</code>
       </div>
       <div class="install-box mono">
         <span class="prompt">$</span> <code>claude mcp add -s user -t stdio kindex -- kin-mcp</code>

--- a/docs/mcp-agent-guide.md
+++ b/docs/mcp-agent-guide.md
@@ -114,7 +114,7 @@ transcript. Capture what should help a future agent or future user.
 ### Claude Code
 
 ```bash
-pip install kindex[mcp]
+uv tool install 'kindex[mcp]'
 claude mcp add --scope user --transport stdio kindex -- kin-mcp
 kin init
 kin setup-claude-md --install
@@ -126,26 +126,29 @@ capture pre-compaction context, and run stop guards.
 
 ### Codex
 
+Add to `~/.codex/config.toml`:
+
+```toml
+[mcp_servers.kindex]
+command = "kin-mcp"
+```
+
+Or automate setup:
+
 ```bash
-pip install kindex[mcp]
+uv tool install 'kindex[mcp]'
 kin init
 kin setup-codex-mcp
 kin setup-agents-md --install --global
-```
-
-Codex uses the same `kin-mcp` server. The `setup-agents-md` command installs
-standing instructions that tell Codex to use kindex proactively.
-
-To ingest saved Codex sessions:
-
-```bash
-kin ingest codex-sessions
+kin ingest codex-sessions  # optional: backfill saved sessions
 ```
 
 ## Human Setup Checklist
 
-1. Install the MCP server for your agent.
-2. Install the agent instruction file (`CLAUDE.md` or `AGENTS.md`).
-3. Initialize kindex with `kin init`.
-4. Run `kin setup-cron` for periodic maintenance.
-5. Backfill saved sessions with `kin ingest codex-sessions` or `kin ingest sessions`.
+1. Install `uv` if not present: `curl -LsSf https://astral.sh/uv/install.sh | sh`
+2. Install kindex: `uv tool install 'kindex[mcp]'`
+3. Install the MCP server for your agent (see Client Setup above).
+4. Install the agent instruction file (`CLAUDE.md` or `AGENTS.md`).
+5. Run `kin init` to initialize the knowledge graph.
+6. Run `kin setup-cron` for periodic maintenance.
+7. Backfill saved sessions: `kin ingest codex-sessions` or `kin ingest sessions`.

--- a/src/kindex/cli.py
+++ b/src/kindex/cli.py
@@ -1876,7 +1876,7 @@ def cmd_whoami(args):
 def cmd_embed(args):
     """Index all nodes for vector similarity search.
 
-    Requires: pip install kindex[vectors]
+    Requires: uv tool install 'kindex[vectors]'  (or: pip install kindex[vectors])
     """
     store = _store(args)
 

--- a/src/kindex/extract.py
+++ b/src/kindex/extract.py
@@ -33,7 +33,7 @@ def _get_client(config: Config):
     except ImportError:
         import sys
         print("Warning: 'anthropic' package not installed. "
-              "Install with: pip install kindex[llm]", file=sys.stderr)
+              "Install with: uv tool install 'kindex[llm]'  (or: pip install kindex[llm])", file=sys.stderr)
         return None
 
 

--- a/src/kindex/llm.py
+++ b/src/kindex/llm.py
@@ -46,7 +46,7 @@ def get_client(config: Config):
     except ImportError:
         import sys
         print("Warning: LLM enabled but 'anthropic' package not installed. "
-              "Install with: pip install kindex[llm]", file=sys.stderr)
+              "Install with: uv tool install 'kindex[llm]'  (or: pip install kindex[llm])", file=sys.stderr)
         return None
 
 

--- a/src/kindex/setup.py
+++ b/src/kindex/setup.py
@@ -151,14 +151,14 @@ def install_codex_mcp(config: "Config", dry_run: bool = False) -> list[str]:
 
     if dry_run:
         actions.append(f"Would add Codex MCP server to {config_path}")
-        actions.append("Would configure: codex mcp add kindex -- kin-mcp")
+        actions.append("Would configure: kin-mcp")
         return actions
 
     config_path.parent.mkdir(parents=True, exist_ok=True)
     prefix = existing.rstrip()
     content = f"{prefix}\n\n{block}" if prefix else block
     config_path.write_text(content)
-    actions.append(f"Added Codex MCP server: kindex -> kin-mcp")
+    actions.append("Added Codex MCP server: kindex -> kin-mcp")
     actions.append(f"Wrote {config_path}")
     return actions
 

--- a/src/kindex/vectors.py
+++ b/src/kindex/vectors.py
@@ -1,7 +1,7 @@
 """Optional vector embedding support via sqlite-vec.
 
 Enables semantic similarity search when installed:
-    pip install kindex[vectors]          # just sqlite-vec; API-based providers work out of the box
+    uv tool install 'kindex[vectors]'    # just sqlite-vec; API-based providers work out of the box
     pip install sentence-transformers    # opt-in for local embeddings (pulls torch + sklearn)
 
 Supports multiple embedding providers:


### PR DESCRIPTION
kin-mcp had to be on `$PATH` before this, meaning users needed to pip install kindex[mcp] first. Now uv handles it at invocation time.

**Before**
```bash
pip install kindex[mcp]
claude mcp add --scope user --transport stdio kindex -- kin-mcp
```

**After**
```bash
claude mcp add --scope user --transport stdio kindex -- uvx --from 'kindex[mcp]' kin-mcp
```

**Key context**

`uv` is required. If it’s not already there (`which uv`), install it with:

```bash
curl -LsSf https://astral.sh/uv/install.sh | sh
```

It’s a single binary, no virtualenv needed. Same tool as ruff, now part of the official Python packaging recommendations — the bet is most people already have it.