### PR TITLE
Add Gemini CLI MCP setup commands

### DIFF
--- a/src/kindex/config.py
+++ b/src/kindex/config.py
@@ -148,6 +148,7 @@ class Config(BaseModel):
     project_dirs: list[str] = Field(default_factory=lambda: ["~/Code", "~/Personal"])
     claude_dir: str = "~/.claude"
     codex_dir: str = "~/.codex"
+    gemini_dir: str = "~/.gemini"
     llm: LLMConfig = Field(default_factory=LLMConfig)
     embedding: EmbeddingConfig = Field(default_factory=EmbeddingConfig)
     budget: BudgetConfig = Field(default_factory=BudgetConfig)
@@ -193,6 +194,10 @@ class Config(BaseModel):
     @property
     def codex_path(self) -> Path:
         return Path(self.codex_dir).expanduser().resolve()
+
+    @property
+    def gemini_path(self) -> Path:
+        return Path(self.gemini_dir).expanduser().resolve()
 
     @property
     def resolved_project_dirs(self) -> list[Path]:

--- a/src/kindex/setup.py
+++ b/src/kindex/setup.py
@@ -199,6 +199,64 @@ def uninstall_codex_mcp(config: "Config", dry_run: bool = False) -> list[str]:
     return actions
 
 
+def install_gemini_mcp(config: "Config", dry_run: bool = False) -> list[str]:
+    """Write Kindex MCP config to ~/.gemini/settings.json."""
+    settings_path = config.gemini_path / "settings.json"
+    actions = []
+
+    if settings_path.exists():
+        data = json.loads(settings_path.read_text())
+    else:
+        data = {}
+
+    mcp_servers = data.setdefault("mcpServers", {})
+    if "kindex" in mcp_servers:
+        actions.append("Gemini MCP server already installed")
+        return actions
+
+    mcp_servers["kindex"] = {"command": "kin-mcp", "args": []}
+
+    if dry_run:
+        actions.append(f"Would add Gemini MCP server to {settings_path}")
+        actions.append('Would configure: mcpServers.kindex = {"command":"kin-mcp","args":[]}')
+        return actions
+
+    settings_path.parent.mkdir(parents=True, exist_ok=True)
+    settings_path.write_text(json.dumps(data, indent=2) + "\n")
+    actions.append("Added Gemini MCP server: kindex -> kin-mcp")
+    actions.append(f"Wrote {settings_path}")
+    return actions
+
+
+def uninstall_gemini_mcp(config: "Config", dry_run: bool = False) -> list[str]:
+    """Remove Kindex MCP config from ~/.gemini/settings.json."""
+    settings_path = config.gemini_path / "settings.json"
+    actions = []
+
+    if not settings_path.exists():
+        return ["No Gemini settings.json found"]
+
+    data = json.loads(settings_path.read_text())
+    mcp_servers = data.get("mcpServers", {})
+
+    if "kindex" not in mcp_servers:
+        return ["No Kindex Gemini MCP server found"]
+
+    if dry_run:
+        actions.append(f"Would remove Gemini MCP server from {settings_path}")
+        return actions
+
+    del mcp_servers["kindex"]
+    if mcp_servers:
+        data["mcpServers"] = mcp_servers
+    else:
+        data.pop("mcpServers", None)
+
+    settings_path.write_text(json.dumps(data, indent=2) + "\n")
+    actions.append(f"Removed Gemini MCP server from {settings_path}")
+    return actions
+
+
 def install_launchd(config: "Config", dry_run: bool = False) -> list[str]:
     """Install macOS launchd plist for kin cron.
 

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -169,6 +169,85 @@ class TestSetupCodex:
         assert 'trust_level = "trusted"' in text
 
 
+class TestSetupGemini:
+    def test_setup_gemini_mcp_installs(self, tmp_path):
+        """Should install Kindex MCP server into Gemini settings.json."""
+        from kindex.setup import install_gemini_mcp
+
+        gemini_dir = tmp_path / ".gemini"
+        gemini_dir.mkdir()
+        settings = gemini_dir / "settings.json"
+        settings.write_text(json.dumps({"theme": "dark"}))
+
+        cfg = Config(data_dir=str(tmp_path), gemini_dir=str(gemini_dir))
+        actions = install_gemini_mcp(cfg)
+
+        assert any("Gemini MCP" in a for a in actions)
+        data = json.loads(settings.read_text())
+        assert data["theme"] == "dark"
+        assert data["mcpServers"]["kindex"]["command"] == "kin-mcp"
+        assert data["mcpServers"]["kindex"]["args"] == []
+
+    def test_setup_gemini_mcp_idempotent(self, tmp_path):
+        """Installing twice should not duplicate the Gemini MCP entry."""
+        from kindex.setup import install_gemini_mcp
+
+        gemini_dir = tmp_path / ".gemini"
+        gemini_dir.mkdir()
+        cfg = Config(data_dir=str(tmp_path), gemini_dir=str(gemini_dir))
+
+        install_gemini_mcp(cfg)
+        actions2 = install_gemini_mcp(cfg)
+
+        assert any("already installed" in a for a in actions2)
+        data = json.loads((gemini_dir / "settings.json").read_text())
+        assert list(data["mcpServers"].keys()).count("kindex") == 1
+
+    def test_setup_gemini_mcp_dry_run_does_not_write(self, tmp_path):
+        """Dry run should not create Gemini settings.json."""
+        from kindex.setup import install_gemini_mcp
+
+        gemini_dir = tmp_path / ".gemini"
+        cfg = Config(data_dir=str(tmp_path), gemini_dir=str(gemini_dir))
+
+        actions = install_gemini_mcp(cfg, dry_run=True)
+
+        assert any("Would add" in a for a in actions)
+        assert not (gemini_dir / "settings.json").exists()
+
+    def test_uninstall_gemini_mcp_removes_only_kindex_entry(self, tmp_path):
+        """Uninstall should preserve unrelated Gemini settings."""
+        from kindex.setup import uninstall_gemini_mcp
+
+        gemini_dir = tmp_path / ".gemini"
+        gemini_dir.mkdir()
+        settings = gemini_dir / "settings.json"
+        settings.write_text(json.dumps({
+            "theme": "dark",
+            "mcpServers": {
+                "kindex": {"command": "kin-mcp", "args": []},
+                "other": {"command": "other-mcp", "args": ["--x"]},
+            },
+        }))
+
+        cfg = Config(data_dir=str(tmp_path), gemini_dir=str(gemini_dir))
+        actions = uninstall_gemini_mcp(cfg)
+
+        assert any("Removed" in a for a in actions)
+        data = json.loads(settings.read_text())
+        assert "kindex" not in data["mcpServers"]
+        assert "other" in data["mcpServers"]
+        assert data["theme"] == "dark"
+
+    def test_setup_gemini_mcp_dry_run_cli(self, tmp_path):
+        """CLI dry run should succeed without writing settings."""
+        d = str(tmp_path)
+        run("init", data_dir=d)
+        r = run("setup-gemini-mcp", "--dry-run", data_dir=d)
+        assert r.returncode == 0
+        assert "Would add Gemini MCP server" in r.stdout
+
+
 class TestSetupCron:
     def test_setup_cron_dry_run(self, tmp_path):
         d = str(tmp_path)


### PR DESCRIPTION
Adds `kin setup-gemini-mcp` and `kin setup-gemini-md` commands, mirroring the existing Codex integration.

## What's added

- `setup-gemini-mcp [--uninstall] [--dry-run]`: reads/writes `~/.gemini/settings.json`, adding `kindex -> kin-mcp` under `mcpServers`
- `setup-gemini-md [--install]`: prints (or appends to `~/.gemini/GEMINI.md`) the recommended kindex session directives
- `Config.gemini_dir` / `gemini_path` for configurable path (default `~/.gemini`)
- Full test coverage in `TestSetupGemini`

This brings Gemini CLI support to parity with Codex, allowing users to install kindex as an MCP server and get recommended directives for their GEMINI.md config.