### PR TITLE
perf: defer node embedding off the add/edit/supersede hot path

### DIFF
--- a/src/kindex/daemon.py
+++ b/src/kindex/daemon.py
@@ -103,6 +103,19 @@ def cron_run(config: "Config", store: "Store", verbose: bool = False) -> dict:
     except Exception:
         results["attention_reviewed"] = 0
 
+    # Drain queued node embeddings. Enqueued cheaply on the add/edit/supersede
+    # hot path; the (possibly networked) embedding cost runs here, off the
+    # agent's critical path.
+    try:
+        from .vectors import drain_embedding_queue
+        if verbose:
+            print("Embedding queued nodes...")
+        embed_drained = drain_embedding_queue(store, config)
+        results["embedded"] = embed_drained.get("embedded", 0)
+        results["embed_pending"] = embed_drained.get("pending", 0)
+    except Exception:
+        results["embedded"] = 0
+
     # 5. Run doctor checks
     if verbose:
         print("Running health checks...")

--- a/src/kindex/store.py
+++ b/src/kindex/store.py
@@ -586,15 +586,13 @@ class Store:
                                   provenance="auto-linked from prov_who",
                                   bidirectional=False)
 
-        # Auto-embed for vector search (best-effort, no failure propagation)
+        # Queue for vector embedding — deferred to the daemon so a slow
+        # embedding provider never stalls the add hot path (best-effort).
         try:
-            from .vectors import is_available, upsert_embedding
-            if is_available():
-                embed_text = f"{title} {content}".strip()
-                if embed_text:
-                    upsert_embedding(self, nid, embed_text)
+            from .vectors import enqueue_embedding
+            enqueue_embedding(self, nid)
         except Exception:
-            pass  # vectors not installed or embed failed — node still created
+            pass  # vectors not installed — node still created
 
         return nid
 
@@ -913,15 +911,14 @@ class Store:
             self._log("edit_node", node_id, updates.get("title", old_title),
                       actor or "", {"diffs": diffs, "type": node_type})
             if "title" in updates or "content" in updates:
-                # Re-embed for vector search (best-effort, like add_node)
+                # Queue re-embedding — deferred to the daemon so a slow
+                # embedding provider never stalls the edit hot path
+                # (best-effort, like add_node).
                 try:
-                    from .vectors import is_available, upsert_embedding
-                    if is_available():
-                        embed_text = f"{new_title} {new_content}".strip()
-                        if embed_text:
-                            upsert_embedding(self, node_id, embed_text)
+                    from .vectors import enqueue_embedding
+                    enqueue_embedding(self, node_id)
                 except Exception:
-                    pass  # vectors not installed or embed failed — edit persisted
+                    pass  # vectors not installed — edit persisted
 
         return self.get_node(node_id)
 
@@ -1057,15 +1054,13 @@ class Store:
         except Exception:
             pass
 
-        # Embed the replacement for vector search (best-effort, like add_node)
+        # Queue the replacement for embedding — deferred to the daemon
+        # (best-effort, like add_node).
         try:
-            from .vectors import is_available, upsert_embedding
-            if is_available():
-                embed_text = f"{title} {text}".strip()
-                if embed_text:
-                    upsert_embedding(self, new_id, embed_text)
+            from .vectors import enqueue_embedding
+            enqueue_embedding(self, new_id)
         except Exception:
-            pass  # vectors not installed or embed failed — node still created
+            pass  # vectors not installed — node still created
 
         return self.get_node(new_id)
 

--- a/src/kindex/vectors.py
+++ b/src/kindex/vectors.py
@@ -288,6 +288,91 @@ def upsert_embedding(store: Store, node_id: str, text: str) -> bool:
         return False
 
 
+EMBED_QUEUE_META = "embed.queue"
+
+
+def enqueue_embedding(store: Store, node_id: str, *, max_queue: int = 2000) -> bool:
+    """Queue a node for (re)embedding by the daemon. Cheap: one small SQLite
+    write, no model load, no network — safe on the add/edit/supersede hot path.
+
+    Deferring keeps a slow embedding provider (a remote API can stall up to its
+    HTTP timeout per call) off the agent's critical path. The daemon drains the
+    queue in cron via ``drain_embedding_queue``. Deduped by node_id; FIFO.
+    """
+    if not node_id:
+        return False
+    try:
+        raw = store.get_meta(EMBED_QUEUE_META)
+        queue = json.loads(raw) if raw else []
+        if not isinstance(queue, list):
+            queue = []
+    except Exception:
+        queue = []
+    # Dedup and move to the tail so the newest edit wins ordering.
+    queue = [n for n in queue if n != node_id]
+    queue.append(node_id)
+    try:
+        store.set_meta(EMBED_QUEUE_META, json.dumps(queue[-max_queue:]))
+        return True
+    except Exception:
+        return False
+
+
+def drain_embedding_queue(store: Store, config: Config | None = None, *,
+                          max_jobs: int = 200) -> dict:
+    """Embed queued nodes. This is where the (possibly networked) embedding cost
+    lives — runs in cron, off the agent's path. Idempotent per node.
+
+    Each node is re-fetched fresh so the embedding reflects its current text.
+    Bounded to ``max_jobs`` attempts per drain; unattempted nodes and transient
+    failures are carried to the next cron (failures re-queued at the tail so a
+    persistently failing node can't starve newer ones).
+    """
+    try:
+        raw = store.get_meta(EMBED_QUEUE_META)
+        queue = json.loads(raw) if raw else []
+        if not isinstance(queue, list):
+            queue = []
+    except Exception:
+        queue = []
+    if not queue:
+        return {"status": "empty", "embedded": 0, "pending": 0}
+    if not is_available():
+        # Backend not installed/usable; leave the (bounded) queue intact in case
+        # it becomes available later.
+        return {"status": "unavailable", "embedded": 0, "pending": len(queue)}
+
+    # De-dup preserving order; drop falsy ids.
+    deduped = list(dict.fromkeys(n for n in queue if n))
+    remaining: list[str] = []
+    embedded = 0
+    attempts = 0
+    for i, node_id in enumerate(deduped):
+        if attempts >= max_jobs:
+            remaining.extend(deduped[i:])  # carry the rest to the next cron
+            break
+        node = store.get_node(node_id)
+        if not node or node.get("status") == "superseded":
+            continue  # node is gone — drop from the queue
+        text = f"{node.get('title') or ''} {node.get('content') or ''}".strip()
+        if not text:
+            continue  # nothing to embed — drop
+        attempts += 1
+        try:
+            ok = upsert_embedding(store, node_id, text)
+        except Exception:
+            ok = False  # provider raised — treat as transient
+        if ok:
+            embedded += 1
+        else:
+            remaining.append(node_id)  # transient (e.g. provider down) — retry
+    try:
+        store.set_meta(EMBED_QUEUE_META, json.dumps(remaining))
+    except Exception:
+        pass
+    return {"status": "ok", "embedded": embedded, "pending": len(remaining)}
+
+
 def delete_embedding(store: Store, node_id: str) -> bool:
     """Remove a node's stored embedding (best-effort).
 

--- a/tests/test_edit_store.py
+++ b/tests/test_edit_store.py
@@ -158,24 +158,36 @@ class TestEditReembed:
         )
         return calls
 
+    def _drain(self, store):
+        from kindex.vectors import drain_embedding_queue
+        return drain_embedding_queue(store)
+
     def test_reembed_on_content_change(self, store, embed_calls):
         nid = store.add_node("Title", content="body", node_type="concept")
-        embed_calls.clear()  # ignore the add_node embed
+        self._drain(store)        # flush the add_node enqueue
+        embed_calls.clear()
         store.edit_node(nid, content="new body")
+        # Embedding is deferred — nothing runs until the daemon drains the queue.
+        assert embed_calls == []
+        self._drain(store)
         assert embed_calls == [(nid, "Title new body")]
 
     def test_reembed_on_append(self, store, embed_calls):
         nid = store.add_node("D", content="base", node_type="decision")
+        self._drain(store)
         embed_calls.clear()
         store.edit_node(nid, append="addendum text")
+        self._drain(store)
         assert len(embed_calls) == 1
         assert embed_calls[0][0] == nid
         assert "addendum text" in embed_calls[0][1]
 
     def test_no_reembed_on_tag_only_change(self, store, embed_calls):
         nid = store.add_node("Tagged", node_type="concept")
+        self._drain(store)
         embed_calls.clear()
         store.edit_node(nid, add_tags=["new-tag"])
+        self._drain(store)
         assert embed_calls == []
 
     def test_embed_failure_does_not_break_edit(self, store, monkeypatch):
@@ -189,6 +201,8 @@ class TestEditReembed:
         nid = store.add_node("Robust", content="a", node_type="concept")
         node = store.edit_node(nid, content="b")
         assert node["content"] == "b"
+        # A provider that raises during the deferred drain must not propagate.
+        vectors.drain_embedding_queue(store)
 
 
 # ── Reserved extra keys ────────────────────────────────────────────────

--- a/tests/test_embed_queue.py
+++ b/tests/test_embed_queue.py
@@ -1,0 +1,132 @@
+"""Tests for the deferred embedding queue (enqueue on the hot path, drain in
+the daemon) — see vectors.enqueue_embedding / drain_embedding_queue.
+
+Deferral keeps a slow embedding provider off the add/edit/supersede hot path;
+these tests pin the queue semantics (dedup, ordering, bounding, transient
+retry) and that the hot path no longer embeds synchronously.
+"""
+
+import json
+
+import pytest
+
+import kindex.vectors as vectors
+from kindex.config import Config
+from kindex.store import Store
+from kindex.vectors import (
+    EMBED_QUEUE_META,
+    drain_embedding_queue,
+    enqueue_embedding,
+)
+
+
+@pytest.fixture
+def store(tmp_path):
+    s = Store(Config(data_dir=str(tmp_path)))
+    yield s
+    s.close()
+
+
+@pytest.fixture
+def embed_calls(monkeypatch):
+    """Capture upsert_embedding calls and pretend the backend is available."""
+    calls = []
+    monkeypatch.setattr(vectors, "is_available", lambda: True)
+    monkeypatch.setattr(
+        vectors, "upsert_embedding",
+        lambda store, node_id, text: calls.append((node_id, text)) or True,
+    )
+    return calls
+
+
+def _queue(store):
+    raw = store.get_meta(EMBED_QUEUE_META)
+    return json.loads(raw) if raw else []
+
+
+class TestEnqueue:
+    def test_enqueue_appends_node_id(self, store):
+        enqueue_embedding(store, "n1")
+        assert _queue(store) == ["n1"]
+
+    def test_enqueue_dedups_moving_to_tail(self, store):
+        enqueue_embedding(store, "a")
+        enqueue_embedding(store, "b")
+        enqueue_embedding(store, "a")  # re-enqueue moves to tail, no duplicate
+        assert _queue(store) == ["b", "a"]
+
+    def test_enqueue_empty_id_is_noop(self, store):
+        assert enqueue_embedding(store, "") is False
+        assert _queue(store) == []
+
+    def test_enqueue_bounds_queue(self, store):
+        for i in range(10):
+            enqueue_embedding(store, f"n{i}", max_queue=3)
+        assert _queue(store) == ["n7", "n8", "n9"]
+
+
+class TestDrain:
+    def test_drain_empty(self, store, embed_calls):
+        assert drain_embedding_queue(store)["status"] == "empty"
+        assert embed_calls == []
+
+    def test_drain_embeds_current_text_and_clears(self, store, embed_calls):
+        nid = store.add_node("Title", content="body", node_type="concept")
+        # add_node enqueued nid but did NOT embed synchronously.
+        assert embed_calls == []
+        assert _queue(store) == [nid]
+
+        res = drain_embedding_queue(store)
+        assert res == {"status": "ok", "embedded": 1, "pending": 0}
+        assert embed_calls == [(nid, "Title body")]
+        assert _queue(store) == []
+
+    def test_drain_skips_missing_and_superseded(self, store, embed_calls):
+        nid = store.add_node("Live", content="x", node_type="concept")
+        enqueue_embedding(store, "ghost-id")           # node never existed
+        store.supersede_node(nid, "Live v2")           # nid -> superseded
+        drain_embedding_queue(store)
+        embedded_ids = {c[0] for c in embed_calls}
+        assert nid not in embedded_ids                 # superseded -> dropped
+        assert "ghost-id" not in embedded_ids          # missing -> dropped
+
+    def test_drain_unavailable_keeps_queue(self, store, monkeypatch):
+        monkeypatch.setattr(vectors, "is_available", lambda: False)
+        enqueue_embedding(store, "n1")
+        res = drain_embedding_queue(store)
+        assert res["status"] == "unavailable"
+        assert _queue(store) == ["n1"]                 # left intact for later
+
+    def test_drain_requeues_transient_failure(self, store, monkeypatch):
+        monkeypatch.setattr(vectors, "is_available", lambda: True)
+        monkeypatch.setattr(
+            vectors, "upsert_embedding",
+            lambda store, node_id, text: False,        # provider down
+        )
+        store.add_node("Flaky", content="x", node_type="concept")
+        res = drain_embedding_queue(store)
+        assert res["embedded"] == 0
+        assert len(_queue(store)) == 1                 # retried next cron
+
+    def test_drain_swallows_raising_provider(self, store, monkeypatch):
+        monkeypatch.setattr(vectors, "is_available", lambda: True)
+
+        def boom(*a, **kw):
+            raise RuntimeError("provider exploded")
+
+        monkeypatch.setattr(vectors, "upsert_embedding", boom)
+        store.add_node("Boom", content="x", node_type="concept")
+        # Must not propagate; node is re-queued for a later attempt.
+        res = drain_embedding_queue(store)
+        assert res["embedded"] == 0
+        assert len(_queue(store)) == 1
+
+    def test_drain_bounded_by_max_jobs(self, store, embed_calls):
+        ids = [store.add_node(f"x{i}", content="c", node_type="concept")
+               for i in range(5)]
+        # add_node already enqueued these five ids; pin the queue to exactly them.
+        store.set_meta(EMBED_QUEUE_META, json.dumps(ids))
+        res = drain_embedding_queue(store, max_jobs=2)
+        assert res["embedded"] == 2
+        assert res["pending"] == 3
+        assert _queue(store) == ids[2:]                # the carried remainder


### PR DESCRIPTION
## Problem

`store.edit_node` / `add_node` / `supersede_node` called `upsert_embedding()` **synchronously on the hot path** (`store.py`). When a remote embedding provider (Voyage/OpenAI/Gemini) is configured, each add/edit could block up to that provider's HTTP timeout (~30s) before returning. This made interactive MCP edits feel sticky and was the prime suspect behind a "kindex tool call then long hang" report.

(The reported 15-minute hang was the *calling* agent spinning after kindex returned — not kindex blocking — but the synchronous embed on the hot path is still the wrong design.)

## Fix

Move embedding to the **enqueue → daemon-drain** pattern already used by the reinforce / sim / attention queues:

- `vectors.enqueue_embedding()` — cheap JSON write to the `embed.queue` meta key (deduped, FIFO, bounded). Called on the hot path instead of embedding.
- `vectors.drain_embedding_queue()` — re-fetches each node fresh, embeds with current text, bounded by `max_jobs`, drops missing/superseded nodes, re-queues transient failures at the tail, and swallows a raising provider.
- The daemon cron drains the queue, off the agent's critical path.

## Trade-off

Vector freshness is now **eventual** (lags until the next cron) rather than immediate. FTS search is unaffected, and `kin embed` remains the full backfill.

## Tests

- New `tests/test_embed_queue.py`: enqueue dedup/ordering/bounding, drain semantics (current-text embed, skip missing/superseded, unavailable backend, transient retry, raising-provider safety, max_jobs bounding).
- `tests/test_edit_store.py::TestEditReembed` updated to the deferred contract.
- Full suite green: **1515 passed**.

No release is cut from this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)