### PR TITLE
fix: scope pull-based context surfaces to the running client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Kindex are documented here. Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.25.6] - 2026-06-27
+
+### Fixed
+- Client scoping now also covers the pull-based context surfaces. `format_context_block`'s full/abridged tiers drop operational nodes — constraints, watches, directives — scoped to a different client when a client is known, so the MCP `context`/`ask` tools no longer surface (for example) an Antigravity-scoped constraint to a Claude session. The MCP server resolves its client from the `KIN_CLIENT` environment variable (a per-client MCP config can set it); unset means no scoping — the unchanged default. Human-facing `kin context` / `kin status` continue to show every node.
+- `prime`'s 24h "Recent activity" section no longer echoes the titles of nodes scoped to a different client; the aggregate activity counts remain complete.
+
 ## [0.25.5] - 2026-06-27
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 [![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
 [![MIT License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
-[![v0.25.5](https://img.shields.io/badge/version-0.25.5-purple.svg)](https://github.com/jmcentire/kindex/releases)
+[![v0.25.6](https://img.shields.io/badge/version-0.25.6-purple.svg)](https://github.com/jmcentire/kindex/releases)
 [![PyPI](https://img.shields.io/pypi/v/kindex.svg)](https://pypi.org/project/kindex/)
 [![MCP Market](https://img.shields.io/badge/MCP%20Market-kindex-blue.svg)](https://mcpmarket.com/server/kindex)
-[![Tests](https://img.shields.io/badge/tests-1522%20passing-brightgreen.svg)](#)
+[![Tests](https://img.shields.io/badge/tests-1525%20passing-brightgreen.svg)](#)
 [![MCP Plugin](https://img.shields.io/badge/MCP-Plugin-orange.svg)](#install-as-agent-mcp-plugin)
 
 **The memory layer AI coding agents don't have.**

--- a/docs/index.html
+++ b/docs/index.html
@@ -265,7 +265,7 @@
       </div>
     </div>
     <div class="badges">
-      <span class="badge green">v0.25.5</span>
+      <span class="badge green">v0.25.6</span>
       <span class="badge orange">MCP Plugin</span>
       <span class="badge blue">52 MCP Tools</span>
       <span class="badge purple">75 CLI Commands</span>
@@ -801,7 +801,7 @@ work_policy:
       MIT License &middot;
       Free
     </p>
-    <p style="margin-top: 8px;">v0.25.5 &middot; MCP Plugin &middot; 52 MCP Tools &middot; 75 CLI Commands &middot; 1522 Tests</p>
+    <p style="margin-top: 8px;">v0.25.6 &middot; MCP Plugin &middot; 52 MCP Tools &middot; 75 CLI Commands &middot; 1525 Tests</p>
     <p style="margin-top: 8px;">Made by <a href="https://github.com/jmcentire">Jeremy McEntire</a></p>
     <p style="margin-top: 8px;">
       <a href="https://exemplar.tools">exemplar.tools</a> &middot;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kindex"
-version = "0.25.5"
+version = "0.25.6"
 description = "The memory layer AI coding agents don't have — persistent knowledge graph for AI workflows"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.jmcentire/kindex",
   "title": "Kindex",
   "description": "Persistent knowledge graph and MCP server for AI workflows with git-tracked project context.",
-  "version": "0.25.5",
+  "version": "0.25.6",
   "repository": {
     "url": "https://github.com/jmcentire/kindex",
     "source": "github"
@@ -13,7 +13,7 @@
     {
       "registryType": "pypi",
       "identifier": "kindex",
-      "version": "0.25.5",
+      "version": "0.25.6",
       "runtimeHint": "pipx",
       "transport": {
         "type": "stdio"

--- a/src/kindex/__init__.py
+++ b/src/kindex/__init__.py
@@ -1,3 +1,3 @@
 """Kindex — Knowledge graph that learns from your conversations."""
 
-__version__ = "0.25.5"
+__version__ = "0.25.6"

--- a/src/kindex/hooks.py
+++ b/src/kindex/hooks.py
@@ -151,15 +151,25 @@ def prime_context(
     recent = store.activity_since(yesterday)
     if recent:
         lines.append("### Recent activity (last 24h)")
-        # Group by action
+        # Group by action. Notable titles for nodes scoped to a different client
+        # are dropped so their titles don't echo into the wrong session (the
+        # aggregate counts stay complete — they reveal no titles).
+        scoping = bool(adapter) and adapter != "plain"
         action_counts: dict[str, int] = {}
         notable: list[str] = []
         for entry in recent:
             action = entry.get("action", "unknown")
             action_counts[action] = action_counts.get(action, 0) + 1
+            if len(notable) >= 5:
+                continue
             target = entry.get("target_title") or entry.get("target_id", "")
-            if target and len(notable) < 5:
-                notable.append(f"{action}: {target}")
+            if not target:
+                continue
+            if scoping:
+                domains = store.get_node_domains(str(entry.get("target_id") or ""))
+                if adapter_scoped_out(domains, adapter):
+                    continue
+            notable.append(f"{action}: {target}")
 
         summary_parts = [f"{count} {action}" for action, count in action_counts.items()]
         lines.append(f"- Activity: {', '.join(summary_parts)}")

--- a/src/kindex/mcp_server.py
+++ b/src/kindex/mcp_server.py
@@ -124,6 +124,27 @@ def _default_agent(agent: str = "") -> str:
     return resolve_agent_id(_get_config())
 
 
+def _mcp_client() -> str | None:
+    """Client identity used to scope pulled context, from the KIN_CLIENT env.
+
+    A per-client MCP config (this server runs one instance per client) can set
+    KIN_CLIENT so context tools drop nodes scoped to a different client. Unset
+    means no scoping — the unchanged default.
+    """
+    from .agent_adapters import normalize_adapter
+    raw = os.environ.get("KIN_CLIENT") or os.environ.get("KINDEX_CLIENT")
+    return normalize_adapter(raw) if raw else None
+
+
+def _scope_results(results: list[dict], client: str | None) -> list[dict]:
+    """Drop search hits scoped to a different client, mirroring prime's retrieval
+    filter so context tools scope both search hits and operational nodes."""
+    if not client:
+        return results
+    from .agent_adapters import adapter_scoped_out
+    return [r for r in results if not adapter_scoped_out(r.get("tags"), client)]
+
+
 def _json(obj: Any, **kw) -> str:
     """JSON serialize with date/path handling."""
     import datetime
@@ -417,11 +438,13 @@ def context(
     from .retrieve import format_context_block, hybrid_search
     from .store import node_expired
 
+    client = _mcp_client()
     if topic:
         results = hybrid_search(store, topic, top_k=15)
     else:
         # Fall back to recent high-weight nodes (skip expired knowledge)
         results = [r for r in store.recent_nodes(n=15) if not node_expired(r)]
+    results = _scope_results(results, client)
 
     if not results:
         return "No relevant knowledge found."
@@ -430,7 +453,7 @@ def context(
     if max_tokens > 0:
         kwargs = {"max_tokens_approx": max_tokens}
 
-    return format_context_block(store, results, query=topic, **kwargs)
+    return format_context_block(store, results, query=topic, adapter=client, **kwargs)
 
 
 @mcp.tool()
@@ -588,13 +611,14 @@ def ask(question: str) -> str:
         qtype = "exploratory"
 
     top_k = {"factual": 5, "procedural": 8, "decision": 10, "exploratory": 12}.get(qtype, 10)
-    results = hybrid_search(store, question, top_k=top_k)
+    client = _mcp_client()
+    results = _scope_results(hybrid_search(store, question, top_k=top_k), client)
 
     if not results:
         return f"[{qtype}] No relevant knowledge found for: {question}"
 
     level = "full" if qtype in ("procedural", "decision") else "abridged"
-    block = format_context_block(store, results, query=question, level=level)
+    block = format_context_block(store, results, query=question, level=level, adapter=client)
     return f"[{qtype} question]\n\n{block}"
 
 
@@ -1135,10 +1159,12 @@ def prime(topic: str = "") -> str:
     from .retrieve import format_context_block, hybrid_search
     from .store import node_expired
 
+    client = _mcp_client()
     if topic:
         results = hybrid_search(store, topic, top_k=15)
     else:
         results = [r for r in store.recent_nodes(n=15) if not node_expired(r)]
+    results = _scope_results(results, client)
 
     if not results:
         return "No knowledge available for priming."
@@ -1148,7 +1174,7 @@ def prime(topic: str = "") -> str:
         f"# Kindex Context\n\n"
         f"Graph: {stats.get('node_count', 0)} nodes, {stats.get('edge_count', 0)} edges\n\n"
     )
-    block = format_context_block(store, results, query=topic, level="full")
+    block = format_context_block(store, results, query=topic, level="full", adapter=client)
     return header + block
 
 

--- a/src/kindex/retrieve.py
+++ b/src/kindex/retrieve.py
@@ -16,7 +16,10 @@ from __future__ import annotations
 import re
 from collections import defaultdict
 from datetime import datetime
+from functools import partial
 from typing import TYPE_CHECKING
+
+from .agent_adapters import adapter_scoped_out
 
 if TYPE_CHECKING:
     from .store import Store
@@ -414,6 +417,7 @@ def format_context_block(
     query: str = "",
     level: str | None = None,
     max_tokens_approx: int | None = None,
+    adapter: str | None = None,
 ) -> str:
     """Format search results as a context block for CLAUDE.md injection.
 
@@ -421,6 +425,10 @@ def format_context_block(
     Auto-selects tier based on max_tokens_approx if level is not specified.
     Enforces token budget: if output exceeds the tier budget, progressively
     drops results until it fits.
+
+    When ``adapter`` names a client, operational nodes scoped to a different
+    client are dropped from the full/abridged tiers; with no adapter every node
+    surfaces (the right default for human-facing ``kin context``).
     """
     if not results:
         return "## Kindex: No relevant context found.\n"
@@ -429,7 +437,7 @@ def format_context_block(
         level = auto_select_tier(max_tokens_approx)
 
     budget = max_tokens_approx or TIER_BUDGETS.get(level, 1500)
-    formatter = _TIER_FORMATTERS.get(level, _format_abridged)
+    formatter = partial(_TIER_FORMATTERS.get(level, _format_abridged), adapter=adapter)
 
     # Try with all results, then progressively trim until within budget
     for n in range(len(results), 0, -1):
@@ -453,9 +461,22 @@ def _gather_domains(results: list[dict]) -> set[str]:
     return domains
 
 
-def _append_operational(store: Store, lines: list[str], verbose: bool = False) -> None:
-    """Append active operational nodes (constraints, watches, etc.) to output."""
+def _append_operational(
+    store: Store, lines: list[str], verbose: bool = False, adapter: str | None = None
+) -> None:
+    """Append active operational nodes (constraints, watches, etc.) to output.
+
+    When ``adapter`` names a client, nodes scoped to a different client (e.g. an
+    Antigravity hook-protocol directive) are dropped, mirroring the attention and
+    prime injection paths. With no adapter, every operational node surfaces — the
+    right default for human-facing ``kin context``/``kin status``.
+    """
     ops = store.operational_summary()
+    if adapter is not None:
+        ops = {
+            k: [n for n in v if not adapter_scoped_out(n.get("tags"), adapter)]
+            for k, v in ops.items()
+        }
 
     if ops["constraints"]:
         lines.append("\n### Active constraints")
@@ -492,7 +513,9 @@ def _append_operational(store: Store, lines: list[str], verbose: bool = False) -
 
 # ── Full tier ─────────────────────────────────────────────────────────
 
-def _format_full(store: Store, results: list[dict], query: str) -> str:
+def _format_full(
+    store: Store, results: list[dict], query: str, adapter: str | None = None
+) -> str:
     """Full context — everything Kindex knows about the active domain."""
     all_domains = _gather_domains(results)
 
@@ -556,14 +579,16 @@ def _format_full(store: Store, results: list[dict], query: str) -> str:
                 lines.append(f"  Rationale: {_strip_frontmatter(d['content'])[:200]}")
 
     # Operational nodes
-    _append_operational(store, lines, verbose=True)
+    _append_operational(store, lines, verbose=True, adapter=adapter)
 
     return "\n".join(lines) + "\n"
 
 
 # ── Abridged tier ─────────────────────────────────────────────────────
 
-def _format_abridged(store: Store, results: list[dict], query: str) -> str:
+def _format_abridged(
+    store: Store, results: list[dict], query: str, adapter: str | None = None
+) -> str:
     """Abridged — key nodes, trimmed content, edges preserved."""
     all_domains = _gather_domains(results)
 
@@ -613,14 +638,16 @@ def _format_abridged(store: Store, results: list[dict], query: str) -> str:
             lines.append(f"- {when}: {d['title']}")
 
     # Active constraints and watches (brief)
-    _append_operational(store, lines, verbose=False)
+    _append_operational(store, lines, verbose=False, adapter=adapter)
 
     return "\n".join(lines) + "\n"
 
 
 # ── Summarized tier ───────────────────────────────────────────────────
 
-def _format_summarized(store: Store, results: list[dict], query: str) -> str:
+def _format_summarized(
+    store: Store, results: list[dict], query: str, adapter: str | None = None
+) -> str:
     """Summarized — paragraph-form narrative per domain cluster."""
     all_domains = _gather_domains(results)
 
@@ -660,7 +687,9 @@ def _format_summarized(store: Store, results: list[dict], query: str) -> str:
 
 # ── Executive tier ────────────────────────────────────────────────────
 
-def _format_executive(store: Store, results: list[dict], query: str) -> str:
+def _format_executive(
+    store: Store, results: list[dict], query: str, adapter: str | None = None
+) -> str:
     """Executive — 2-3 sentences per active thread. Minimum to orient."""
     all_domains = _gather_domains(results)
     domain_str = ", ".join(sorted(all_domains)[:4])
@@ -686,7 +715,9 @@ def _format_executive(store: Store, results: list[dict], query: str) -> str:
 
 # ── Index tier ────────────────────────────────────────────────────────
 
-def _format_index(store: Store, results: list[dict], query: str) -> str:
+def _format_index(
+    store: Store, results: list[dict], query: str, adapter: str | None = None
+) -> str:
     """Index — node titles and edge types only. Just the map."""
     titles = []
     for r in results:

--- a/src/kindex/store.py
+++ b/src/kindex/store.py
@@ -606,6 +606,23 @@ class Store:
         self.conn.commit()
         return self._row_to_dict(row)
 
+    def get_node_domains(self, node_id: str) -> list[str]:
+        """Read a node's domains/tags without touching last_accessed (non-mutating).
+
+        Used on hot paths (e.g. prime) that only need a node's client scope and
+        must not bump the freshness-decay signal or commit per lookup.
+        """
+        if not node_id:
+            return []
+        row = self.conn.execute(
+            "SELECT domains FROM nodes WHERE id = ?", (node_id,)).fetchone()
+        if not row or not row[0]:
+            return []
+        try:
+            return json.loads(row[0])
+        except (json.JSONDecodeError, TypeError):
+            return []
+
     def get_node_by_title(self, title: str) -> dict | None:
         """Match by title or AKA (case-insensitive)."""
         # Exact title match

--- a/tests/test_context_tiers.py
+++ b/tests/test_context_tiers.py
@@ -34,6 +34,47 @@ def populated_store(tmp_path):
     s.close()
 
 
+class TestOperationalScoping:
+    def test_format_context_block_scopes_operational_by_adapter(self, tmp_path):
+        cfg = Config(data_dir=str(tmp_path))
+        store = Store(cfg)
+        store.add_node("Stigmergy", content="Coordination through environmental traces",
+                       node_id="stig", domains=["systems"], weight=1.0)
+        # An Antigravity-scoped constraint — an operational node that _append_operational
+        # always renders in the full/abridged tiers, regardless of the search results.
+        store.add_node(
+            "Antigravity hook must return decision JSON",
+            node_type="constraint",
+            node_id="ag-con",
+            content="Antigravity PreToolUse stdout must be decision JSON.",
+            domains=["antigravity"],
+            extra={"action": "warn"},
+        )
+        results = hybrid_search(store, "stigmergy", top_k=5)
+        marker = "Antigravity hook must return decision JSON"
+
+        # No adapter: every operational node surfaces (human-facing kin context).
+        assert marker in format_context_block(store, results, query="stigmergy", level="full")
+        # Claude / Codex: the Antigravity-scoped constraint is dropped.
+        assert marker not in format_context_block(
+            store, results, query="stigmergy", level="full", adapter="claude")
+        assert marker not in format_context_block(
+            store, results, query="stigmergy", level="abridged", adapter="codex")
+        # Antigravity itself still sees it.
+        assert marker in format_context_block(
+            store, results, query="stigmergy", level="full", adapter="antigravity")
+        store.close()
+
+    def test_mcp_scope_results_filters_foreign_client(self):
+        from kindex.mcp_server import _scope_results
+        rows = [{"id": "a", "tags": ["antigravity"]}, {"id": "b", "tags": ["systems"]}]
+        # A client-scoped search hit is dropped for a foreign client...
+        assert [r["id"] for r in _scope_results(rows, "claude")] == ["b"]
+        # ...kept for its own client, and unfiltered when no client is set.
+        assert [r["id"] for r in _scope_results(rows, "antigravity")] == ["a", "b"]
+        assert [r["id"] for r in _scope_results(rows, None)] == ["a", "b"]
+
+
 class TestAutoSelectTier:
     def test_default_is_abridged(self):
         assert auto_select_tier(None) == "abridged"

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -81,13 +81,13 @@ class TestPrimeContext:
             domains=["antigravity"],
         )
 
-        # Assert on the directive's content (carried only by the scoped retrieval /
-        # operational sections); the title also appears in the transient 24h "Recent
-        # activity" changelog, which is intentionally not adapter-scoped. The topic
-        # matches the directive so it surfaces into the content-bearing Key concepts.
+        # The directive's CONTENT (Key concepts / Directives) and its TITLE (the now
+        # also-scoped 24h "Recent activity" changelog) must both stay out of a Claude
+        # session. The topic matches so it would otherwise surface into Key concepts.
         topic = "Antigravity PreToolUse hook protocol"
         claude_out = prime_context(store, topic=topic, max_tokens=1500, adapter="claude")
         assert "nested camelCase JSON" not in claude_out
+        assert "Antigravity PreToolUse hook protocol" not in claude_out
 
         ag_out = prime_context(store, topic=topic, max_tokens=1500, adapter="antigravity")
         assert "nested camelCase JSON" in ag_out

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -33,6 +33,19 @@ class TestNodeOperations:
         assert node["id"] == "ut1"
         assert store.get_node_by_title("unique title") is not None  # case insensitive
 
+    def test_get_node_domains_is_non_mutating(self, store):
+        nid = store.add_node("Tagged", domains=["antigravity", "hooks"])
+        # Returns the node's domains without touching last_accessed (non-mutating).
+        before = store.conn.execute(
+            "SELECT last_accessed FROM nodes WHERE id = ?", (nid,)).fetchone()[0]
+        assert store.get_node_domains(nid) == ["antigravity", "hooks"]
+        after = store.conn.execute(
+            "SELECT last_accessed FROM nodes WHERE id = ?", (nid,)).fetchone()[0]
+        assert before == after
+        # Missing node / empty id -> empty list, never raises.
+        assert store.get_node_domains("does-not-exist") == []
+        assert store.get_node_domains("") == []
+
     def test_update_node(self, store):
         nid = store.add_node("Original")
         store.update_node(nid, title="Updated", weight=0.9)


### PR DESCRIPTION
## Summary

Closes the two pull-based context surfaces deliberately deferred in v0.25.5 (watch `36bd809b5cc2`), so there are no remaining unscoped client-leak surfaces.

- **`format_context_block` full/abridged tiers** now drop operational nodes (constraints, watches, directives) scoped to a different client, threaded through all five tier formatters via `functools.partial`. Default (no client) is unchanged — human-facing `kin context`/`kin status` still show everything.
- **MCP `context`/`ask` tools** resolve their client from the `KIN_CLIENT` env (a per-client MCP config can set it) and filter **both** the search results and the operational appendix, symmetric with the prime hook. Unset ⇒ no scoping.
- **prime's 24h "Recent activity"** no longer echoes titles of other-client nodes. The lookup uses a new non-mutating `store.get_node_domains()` so priming neither commits per entry nor bumps the `last_accessed` freshness signal.

## Review

An adversarial verification pass returned **ship** and flagged two minors, both fixed in this PR:
1. The recent-activity lookup originally used `store.get_node()`, a *mutating* read (commits `last_accessed` per call) on the prime hot path → replaced with non-mutating `get_node_domains()`.
2. MCP `context`/`ask` scoped only the operational appendix, not the search results → now filter results too (symmetric with prime).

## Tests

**1525 pass** (+2 lock-in tests: non-mutating `get_node_domains`, and `_scope_results` filtering), plus the operational-appendix scoping and strengthened prime title-scoping assertions.

Bumps version to **0.25.6**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
