### PR TITLE
feat: structured merge driver for .kin artifacts (kin merge-kin)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to Kindex are documented here. Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.26.0] - 2026-06-27
+
+### Added
+- **Structured merge driver for `.kin` artifacts.** `.kin/index.json` and `.kin/code-map.json` are generated, id-keyed JSON snapshots — git's line-based merge conflicts on them needlessly. The new `kin merge-kin` git merge driver does a structured 3-way **union** instead: for `index.json`, union nodes by id (newer `updated_at` wins, base detects deletions) and recompute the derived header; for `code-map.json`, union nodes/edges/layer members and recompute the tour. This is lossless across machines (regenerating `index.json` from one machine's local DB would drop the other branch's nodes), and the result is byte-identical to what `kin index` would emit, so a later regeneration produces no spurious diff. Install per repo with `kin setup-merge`, which registers the driver in `.git/config` and points `.kin/index.json` / `.kin/code-map.json` at it via `.gitattributes` (repos without the driver registered fall back to git's default merge).
+
+### Changed
+- `.kin/index.json` no longer carries a volatile `source_updated_at` timestamp. It changed on every regeneration — churning git history and conflicting on every concurrent merge — while the commit time already records snapshot freshness and each node keeps its own `updated_at`.
+
 ## [0.25.6] - 2026-06-27
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 [![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
 [![MIT License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
-[![v0.25.6](https://img.shields.io/badge/version-0.25.6-purple.svg)](https://github.com/jmcentire/kindex/releases)
+[![v0.26.0](https://img.shields.io/badge/version-0.26.0-purple.svg)](https://github.com/jmcentire/kindex/releases)
 [![PyPI](https://img.shields.io/pypi/v/kindex.svg)](https://pypi.org/project/kindex/)
 [![MCP Market](https://img.shields.io/badge/MCP%20Market-kindex-blue.svg)](https://mcpmarket.com/server/kindex)
-[![Tests](https://img.shields.io/badge/tests-1525%20passing-brightgreen.svg)](#)
+[![Tests](https://img.shields.io/badge/tests-1540%20passing-brightgreen.svg)](#)
 [![MCP Plugin](https://img.shields.io/badge/MCP-Plugin-orange.svg)](#install-as-agent-mcp-plugin)
 
 **The memory layer AI coding agents don't have.**
@@ -538,8 +538,15 @@ Kindex resolves project config from `--project-path`, then `KIN_PROJECT`, then
 the git worktree root, then the current directory. User config still lives in
 `~/.config/kindex/kin.yaml` and deep-merges below project config, so user
 preferences remain local while the repo's work contract travels with the repo.
-Generated `.kin/` snapshots use canonical ordering and source-derived time
-metadata so repeated exports of unchanged source do not churn Git diffs.
+Generated `.kin/` snapshots use canonical, id-keyed ordering and omit volatile
+timestamps so repeated exports of unchanged source do not churn Git diffs.
+Concurrent branches merge them without manual conflicts via a structured merge
+driver: run `kin setup-merge` once per clone to register it. `.kin/index.json`
+is then unioned by node id (newer `updated_at` wins) and `.kin/code-map.json` by
+node/edge/layer — lossless across machines (regenerating from one machine's local
+DB would drop the other branch's nodes), with output byte-identical to a fresh
+`kin index`. `kin merge-kin` is the driver git invokes; repos without it
+registered fall back to git's default merge.
 Tracked `.kin` artifacts must be self-contained and machine-portable: code-map
 paths are repo-relative POSIX paths, and task/report metadata must not point at
 `$HOME`, `/Users/...`, `/tmp/...`, or another developer-local filesystem
@@ -705,6 +712,7 @@ Code structure lives in the same graph as your decisions, watches, and constrain
 | `kin watch` | Watch for new sessions and ingest them (--interval) |
 | `kin analytics` | Archive session analytics and activity heatmap |
 | `kin index` | Write .kin/index.json for git tracking |
+| `kin merge-kin` | Git merge driver: structured union merge of `.kin` artifacts (invoked by git) |
 
 ### Infrastructure
 | Command | Description |
@@ -713,6 +721,7 @@ Code structure lives in the same graph as your decisions, watches, and constrain
 | `kin config [show\|get\|set]` | View or edit configuration |
 | `kin agent-config [show\|set]` | View or tune per-client/per-instance agent behavior overrides |
 | `kin policy [show\|check]` | Show or enforce project work policy from `.kin/config` |
+| `kin setup-merge` | Register the `.kin` structured merge driver in the current git repo |
 | `kin setup-hooks` | Install lifecycle hooks into Claude Code |
 | `kin setup-codex-hooks` | Install prompt-time attention hook into Codex |
 | `kin setup-codex-mcp` | Install kindex MCP server into Codex |

--- a/docs/index.html
+++ b/docs/index.html
@@ -265,10 +265,10 @@
       </div>
     </div>
     <div class="badges">
-      <span class="badge green">v0.25.6</span>
+      <span class="badge green">v0.26.0</span>
       <span class="badge orange">MCP Plugin</span>
       <span class="badge blue">52 MCP Tools</span>
-      <span class="badge purple">75 CLI Commands</span>
+      <span class="badge purple">77 CLI Commands</span>
       <span class="badge">MIT License</span>
       <span class="badge">Free</span>
     </div>
@@ -801,7 +801,7 @@ work_policy:
       MIT License &middot;
       Free
     </p>
-    <p style="margin-top: 8px;">v0.25.6 &middot; MCP Plugin &middot; 52 MCP Tools &middot; 75 CLI Commands &middot; 1525 Tests</p>
+    <p style="margin-top: 8px;">v0.26.0 &middot; MCP Plugin &middot; 52 MCP Tools &middot; 77 CLI Commands &middot; 1540 Tests</p>
     <p style="margin-top: 8px;">Made by <a href="https://github.com/jmcentire">Jeremy McEntire</a></p>
     <p style="margin-top: 8px;">
       <a href="https://exemplar.tools">exemplar.tools</a> &middot;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kindex"
-version = "0.25.6"
+version = "0.26.0"
 description = "The memory layer AI coding agents don't have — persistent knowledge graph for AI workflows"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.jmcentire/kindex",
   "title": "Kindex",
   "description": "Persistent knowledge graph and MCP server for AI workflows with git-tracked project context.",
-  "version": "0.25.6",
+  "version": "0.26.0",
   "repository": {
     "url": "https://github.com/jmcentire/kindex",
     "source": "github"
@@ -13,7 +13,7 @@
     {
       "registryType": "pypi",
       "identifier": "kindex",
-      "version": "0.25.6",
+      "version": "0.26.0",
       "runtimeHint": "pipx",
       "transport": {
         "type": "stdio"

--- a/src/kindex/__init__.py
+++ b/src/kindex/__init__.py
@@ -1,3 +1,3 @@
 """Kindex — Knowledge graph that learns from your conversations."""
 
-__version__ = "0.25.6"
+__version__ = "0.26.0"

--- a/src/kindex/cli.py
+++ b/src/kindex/cli.py
@@ -2128,6 +2128,28 @@ def cmd_index(args):
     store.close()
 
 
+def cmd_merge_kin(args):
+    """Git merge driver for .kin artifacts — structured union, no manual conflicts.
+
+    Invoked by git as ``kin merge-kin %O %A %B %P``. Writes the merged result to
+    the ours/%A file and exits 0 when resolved; exits 1 (declining) for an
+    unrecognized file or invalid JSON, leaving the conflict for git to record
+    so it can be resolved manually.
+    """
+    from .kin_merge import merge_kin_files
+
+    merged = merge_kin_files(
+        getattr(args, "path", "") or "",
+        getattr(args, "base", "") or "",
+        getattr(args, "ours", "") or "",
+        getattr(args, "theirs", "") or "",
+    )
+    if merged is None:
+        sys.exit(1)
+    Path(args.ours).write_text(merged)
+    print(f"merge-kin: resolved {args.path}", file=sys.stderr)
+
+
 # ── sync-links ────────────────────────────────────────────────────────
 
 def cmd_sync_links(args):
@@ -5107,6 +5129,29 @@ def cmd_setup_cursor_rules(args):
         print(block)
 
 
+def cmd_setup_merge(args):
+    """Install/uninstall the .kin structured merge driver in the current git repo."""
+    from .setup import git_repo_root, install_merge_driver, uninstall_merge_driver
+
+    root = git_repo_root(getattr(args, "project_path", None) or os.getcwd())
+    if root is None:
+        print("Error: setup-merge must run inside a git repository", file=sys.stderr)
+        sys.exit(1)
+    dry_run = getattr(args, "dry_run", False)
+    uninstall = getattr(args, "uninstall", False)
+    actions = (uninstall_merge_driver if uninstall else install_merge_driver)(
+        root, dry_run=dry_run
+    )
+    for a in actions:
+        print(f"  {a}")
+    if not uninstall and not dry_run:
+        print(
+            "\n.kin/index.json and .kin/code-map.json now merge via `kin merge-kin`.\n"
+            "Commit the updated .gitattributes so collaborators inherit it; each\n"
+            "clone runs `kin setup-merge` once to register the local driver."
+        )
+
+
 def _kindex_claude_md_block() -> str:
     """Generate the recommended CLAUDE.md block for kindex integration."""
     return """\
@@ -6054,6 +6099,27 @@ def build_parser() -> argparse.ArgumentParser:
     s.add_argument("--output-dir", type=str, help="Output directory (default: current dir)")
     _common(s)
     s.set_defaults(func=cmd_index)
+
+    # merge-kin (git merge driver for .kin artifacts)
+    s = sub.add_parser(
+        "merge-kin",
+        help="Git merge driver for .kin artifacts (structured union; called by git)",
+    )
+    s.add_argument("base", help="Ancestor/base version (git %%O)")
+    s.add_argument("ours", help="Current/ours version + output target (git %%A)")
+    s.add_argument("theirs", help="Other/theirs version (git %%B)")
+    s.add_argument("path", help="In-repo pathname (git %%P)")
+    s.set_defaults(func=cmd_merge_kin)
+
+    # setup-merge (install the merge driver into the current repo)
+    s = sub.add_parser(
+        "setup-merge",
+        help="Install the .kin structured merge driver into the current git repo",
+    )
+    s.add_argument("--project-path", help="Repo path (default: current directory)")
+    s.add_argument("--dry-run", action="store_true", help="Show what would be done")
+    s.add_argument("--uninstall", action="store_true", help="Remove the merge driver")
+    s.set_defaults(func=cmd_setup_merge)
 
     # sync-links
     s = sub.add_parser("sync-links", help="Update node content with connection references")

--- a/src/kindex/ingest.py
+++ b/src/kindex/ingest.py
@@ -936,10 +936,6 @@ def _node_time(node: dict) -> str:
     )
 
 
-def _latest_node_time(nodes: list[dict]) -> str:
-    return max((_node_time(n) for n in nodes), default="")
-
-
 def _kin_index_node(node: dict) -> dict:
     return {
         "domains": sorted(node.get("domains") or []),
@@ -1064,12 +1060,15 @@ def write_kin_index(store: "Store", output_dir: Path) -> Path:
         ).fetchall()
         nodes = [store._row_to_dict(r) for r in rows]
 
+    # NB: no volatile timestamp here (e.g. source_updated_at). It would change on
+    # every regeneration, churning git history and conflicting on every concurrent
+    # merge; the commit time already records snapshot freshness. The file is a pure
+    # function of the node set so a structured union merge stays lossless.
     index = {
         "domains": sorted(set(d for n in nodes for d in (n.get("domains") or []))),
         "node_count": len(nodes),
         "nodes": [_kin_index_node(n) for n in nodes],
         "repo": repo_slug,
-        "source_updated_at": _latest_node_time(nodes),
         "version": 1,
     }
 

--- a/src/kindex/kin_merge.py
+++ b/src/kindex/kin_merge.py
@@ -1,0 +1,237 @@
+"""Structured 3-way merge for git-tracked ``.kin`` artifacts.
+
+``.kin/index.json`` and ``.kin/code-map.json`` are generated, id-keyed JSON
+snapshots. Git's line-based merge conflicts on them needlessly — they are sorted
+node lists, so the correct merge is a structured union keyed by node id, not a
+textual 3-way diff. This module powers the ``kin merge-kin`` git merge driver.
+
+Why a union rather than "regenerate from the graph": ``index.json`` projects the
+local SQLite DB, which is NOT in git. Regenerating from one machine's DB would
+silently drop the *other* branch's concept/decision nodes (that DB never ingested
+them). A union of the two committed files is lossless across machines. The result
+is byte-identical to what ``kin index`` would emit for the merged node set, so a
+later regeneration produces no spurious diff.
+
+``code-map.json`` projects the code (which IS in the merge tree), so its content
+collections are unioned here too; ``kin code-map`` is the canonical refresh for
+the commit-tied ``project`` metadata.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Callable
+
+
+def load_json(path: str | Path) -> dict | None:
+    """Load a ``.kin`` side for merging.
+
+    Returns ``None`` for an absent/empty side (git passes an empty file when a
+    file exists on only one branch). Raises ``ValueError`` on non-empty invalid
+    JSON so the driver can decline and let git fall back to a normal conflict.
+    """
+    p = Path(path)
+    if not p.exists():
+        return None
+    text = p.read_text()
+    if not text.strip():
+        return None
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"invalid JSON in {path}: {exc}") from exc
+    return data if isinstance(data, dict) else None
+
+
+def dumps_kin(obj: dict) -> str:
+    """Serialize ``index.json`` exactly as ``write_kin_index`` does (sort_keys),
+    so a later ``kin index`` regeneration yields no diff."""
+    return json.dumps(obj, indent=2, sort_keys=True) + "\n"
+
+
+def dumps_code_map(obj: dict) -> str:
+    """Serialize ``code-map.json`` exactly as ``kin export code-map`` does — no
+    ``sort_keys`` (insertion-order keys), matching the canonical exporter so a
+    later regeneration yields no diff. The merge reuses the original node/layer
+    dicts, so their key order is already the exporter's."""
+    return json.dumps(obj, indent=2) + "\n"
+
+
+def _three_way_union(
+    base: list[dict] | None,
+    ours: list[dict] | None,
+    theirs: list[dict] | None,
+    key: Callable[[dict], Any],
+    pick: Callable[[dict, dict], dict] | None = None,
+) -> dict[Any, dict]:
+    """3-way set merge of id-keyed item lists.
+
+    Union of ``ours`` and ``theirs``; on a key present in both, ``pick`` chooses
+    (default: keep ``ours``). ``base`` is used to honor deletions: an item present
+    on exactly one side and unchanged there from base was deleted on the other
+    side, so it is dropped. Returns a key -> item dict.
+    """
+    om = {key(x): x for x in (base or [])}
+    am = {key(x): x for x in (ours or [])}
+    bm = {key(x): x for x in (theirs or [])}
+    out: dict[Any, dict] = {}
+    for k in set(am) | set(bm):
+        xa, xb = am.get(k), bm.get(k)
+        if xa is not None and xb is not None:
+            out[k] = pick(xa, xb) if pick else xa
+        elif xa is not None:
+            if k in om and xa == om[k]:
+                continue  # unchanged on ours, deleted on theirs
+            out[k] = xa
+        else:
+            if k in om and xb == om[k]:
+                continue  # unchanged on theirs, deleted on ours
+            out[k] = xb
+    return out
+
+
+def _newer(a: dict, b: dict) -> dict:
+    """Pick the node with the later ``updated_at`` (ISO strings sort lexically).
+
+    On an exact timestamp tie, ``a`` (ours) wins — deterministic per merge but
+    direction-dependent. Acceptable: the snapshot is advisory and a later
+    ``kin index`` from the authoritative DB overwrites it regardless.
+    """
+    return b if str(b.get("updated_at", "")) > str(a.get("updated_at", "")) else a
+
+
+def merge_index(
+    base: dict | None, ours: dict | None, theirs: dict | None
+) -> dict:
+    """Union ``.kin/index.json`` node sets; recompute the derived header."""
+    head = ours or theirs or {}
+    merged = _three_way_union(
+        (base or {}).get("nodes"),
+        (ours or {}).get("nodes"),
+        (theirs or {}).get("nodes"),
+        key=lambda n: n["id"],
+        pick=_newer,
+    )
+    nodes = [merged[k] for k in sorted(merged)]
+    return {
+        "domains": sorted({d for n in nodes for d in (n.get("domains") or [])}),
+        "node_count": len(nodes),
+        "nodes": nodes,
+        "repo": head.get("repo"),
+        "version": head.get("version", 1),
+    }
+
+
+def merge_code_map(
+    base: dict | None, ours: dict | None, theirs: dict | None
+) -> dict:
+    """Union ``.kin/code-map.json`` content collections.
+
+    Nodes/edges are unioned (lossless across branches); layers union their
+    members; ``tour`` is recomputed from the merged layers. ``project`` keeps
+    ours' commit-tied metadata (``kin code-map`` refreshes it) but unions the
+    detected ``languages``.
+    """
+    o, a, b = base or {}, ours or {}, theirs or {}
+
+    node_map = _three_way_union(
+        o.get("nodes"), a.get("nodes"), b.get("nodes"), key=lambda n: n["id"]
+    )
+    # Match the exporter's _canonical_code_node_key order: (filePath, type, id).
+    nodes = sorted(
+        node_map.values(),
+        key=lambda n: (n.get("filePath", ""), n.get("type", ""), n.get("id", "")),
+    )
+
+    edge_map = _three_way_union(
+        o.get("edges"), a.get("edges"), b.get("edges"),
+        key=lambda e: (e.get("source"), e.get("target"), e.get("type")),
+    )
+    edges = sorted(
+        edge_map.values(),
+        key=lambda e: (e.get("source", ""), e.get("target", ""), e.get("type", "")),
+    )
+
+    # Layers: union by id, union member node ids.
+    layers_by_id: dict[Any, dict] = {}
+    for layer in (a.get("layers") or []) + (b.get("layers") or []):
+        lid = layer.get("id")
+        existing = layers_by_id.get(lid)
+        if existing is None:
+            layers_by_id[lid] = {**layer, "nodeIds": list(layer.get("nodeIds") or [])}
+        else:
+            existing["nodeIds"] = sorted(
+                set(existing["nodeIds"]) | set(layer.get("nodeIds") or [])
+            )
+    present_ids = {n["id"] for n in nodes}
+    layers = []
+    for lid in sorted(layers_by_id, key=lambda k: str(k)):
+        layer = layers_by_id[lid]
+        members = sorted(nid for nid in layer.get("nodeIds") or [] if nid in present_ids)
+        layers.append({**layer, "nodeIds": members})
+
+    tour = [
+        {
+            "order": i + 1,
+            "title": layer.get("name"),
+            "description": f"Review {len(layer['nodeIds'])} node(s) in the {layer.get('name')} layer.",
+            "nodeIds": layer["nodeIds"][:25],
+        }
+        for i, layer in enumerate(layers)
+    ]
+
+    project = dict(a.get("project") or b.get("project") or {})
+    langs = set(project.get("languages") or [])
+    langs |= set((b.get("project") or {}).get("languages") or [])
+    project["languages"] = sorted(langs)
+
+    return {
+        "version": a.get("version") or b.get("version"),
+        "project": project,
+        "nodes": nodes,
+        "edges": edges,
+        "layers": layers,
+        "tour": tour,
+    }
+
+
+# Dispatch by the in-repo filename git passes as %P. Each artifact has its own
+# serializer matching its canonical writer so a post-merge regeneration is a no-op.
+_MERGERS: dict[str, Callable[[dict | None, dict | None, dict | None], dict]] = {
+    "index.json": merge_index,
+    "code-map.json": merge_code_map,
+}
+_SERIALIZERS: dict[str, Callable[[dict], str]] = {
+    "index.json": dumps_kin,
+    "code-map.json": dumps_code_map,
+}
+
+
+def merge_for(
+    name: str, base: dict | None, ours: dict | None, theirs: dict | None
+) -> dict | None:
+    """Merge by ``.kin`` filename; ``None`` if the filename is not recognized."""
+    merger = _MERGERS.get(Path(name).name)
+    if merger is None:
+        return None
+    return merger(base, ours, theirs)
+
+
+def merge_kin_files(
+    repo_path: str, base_file: str, ours_file: str, theirs_file: str
+) -> str | None:
+    """Driver entrypoint. Returns merged text to write to the ours (%A) file, or
+    ``None`` to decline (unknown file / invalid JSON) so git keeps the conflict."""
+    if Path(repo_path).name not in _MERGERS:
+        return None
+    try:
+        base = load_json(base_file)
+        ours = load_json(ours_file)
+        theirs = load_json(theirs_file)
+    except ValueError:
+        return None
+    merged = merge_for(repo_path, base, ours, theirs)
+    if merged is None:
+        return None
+    return _SERIALIZERS[Path(repo_path).name](merged)

--- a/src/kindex/setup.py
+++ b/src/kindex/setup.py
@@ -993,3 +993,96 @@ def _find_kin_path() -> str:
     # Fallback to python -m
     import sys
     return f"{sys.executable} -m kindex.cli"
+
+
+# ── .kin structured merge driver (project-level) ─────────────────────────
+
+_KIN_MERGE_ATTRS = (
+    ".kin/index.json merge=kindex",
+    ".kin/code-map.json merge=kindex",
+)
+_KIN_MERGE_ATTR_HEADER = "# Kindex generated artifacts: structured union merge"
+
+
+def git_repo_root(start: "str | Path | None" = None) -> "Path | None":
+    """Repo top-level for ``start`` (cwd by default), or None if not a git repo."""
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            cwd=str(start or Path.cwd()),
+            capture_output=True, text=True, timeout=5,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if result.returncode != 0 or not result.stdout.strip():
+        return None
+    return Path(result.stdout.strip())
+
+
+def install_merge_driver(root: "Path", dry_run: bool = False) -> list[str]:
+    """Register the ``kin merge-kin`` git merge driver + ``.gitattributes``.
+
+    The driver definition lives in the repo's local ``.git/config`` (not shared),
+    while ``.gitattributes`` (committed) points the ``.kin`` artifacts at it. Repos
+    without the driver registered fall back to git's default merge gracefully.
+    """
+    actions: list[str] = []
+    driver_cmd = f"{_find_kin_path()} merge-kin %O %A %B %P"
+    for key, value in (
+        ("merge.kindex.name", "Kindex .kin artifact structured merge"),
+        ("merge.kindex.driver", driver_cmd),
+    ):
+        if dry_run:
+            actions.append(f"[dry-run] git config {key} = {value}")
+            continue
+        subprocess.run(["git", "-C", str(root), "config", key, value],
+                       capture_output=True, text=True, timeout=5)
+        actions.append(f"git config {key} = {value}")
+
+    attrs_path = root / ".gitattributes"
+    existing = attrs_path.read_text().splitlines() if attrs_path.exists() else []
+    have = {line.strip() for line in existing}
+    missing = [a for a in _KIN_MERGE_ATTRS if a not in have]
+    if not missing:
+        actions.append(f".gitattributes already current ({attrs_path})")
+        return actions
+    if dry_run:
+        actions.append(f"[dry-run] add to .gitattributes: {missing}")
+        return actions
+    lines = list(existing)
+    if lines and lines[-1].strip():
+        lines.append("")
+    lines.append(_KIN_MERGE_ATTR_HEADER)
+    lines.extend(missing)
+    attrs_path.write_text("\n".join(lines) + "\n")
+    actions.append(f"updated {attrs_path} (+{len(missing)} entries)")
+    return actions
+
+
+def uninstall_merge_driver(root: "Path", dry_run: bool = False) -> list[str]:
+    """Remove the merge driver config and ``.gitattributes`` entries."""
+    actions: list[str] = []
+    if dry_run:
+        actions.append("[dry-run] git config --remove-section merge.kindex")
+    else:
+        r = subprocess.run(
+            ["git", "-C", str(root), "config", "--remove-section", "merge.kindex"],
+            capture_output=True, text=True, timeout=5,
+        )
+        actions.append(
+            "removed git config section merge.kindex" if r.returncode == 0
+            else "git config section merge.kindex not present"
+        )
+    attrs_path = root / ".gitattributes"
+    if attrs_path.exists():
+        drop = set(_KIN_MERGE_ATTRS) | {_KIN_MERGE_ATTR_HEADER}
+        kept = [ln for ln in attrs_path.read_text().splitlines() if ln.strip() not in drop]
+        if dry_run:
+            actions.append(f"[dry-run] strip kindex entries from {attrs_path}")
+        elif any(ln.strip() for ln in kept):
+            attrs_path.write_text("\n".join(kept).rstrip() + "\n")
+            actions.append(f"stripped kindex entries from {attrs_path}")
+        else:
+            attrs_path.write_text("")
+            actions.append(f"cleared {attrs_path}")
+    return actions

--- a/tests/test_kin_merge.py
+++ b/tests/test_kin_merge.py
@@ -1,0 +1,271 @@
+"""Tests for the structured .kin merge driver (kin merge-kin)."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from kindex.kin_merge import (
+    dumps_code_map,
+    dumps_kin,
+    load_json,
+    merge_code_map,
+    merge_for,
+    merge_index,
+    merge_kin_files,
+)
+
+
+def _node(nid, updated_at, domains=None, title=None):
+    return {
+        "id": nid,
+        "title": title or nid.upper(),
+        "type": "concept",
+        "domains": domains or [],
+        "updated_at": updated_at,
+        "weight": 0.5,
+    }
+
+
+def _index(nodes):
+    return {
+        "domains": sorted({d for n in nodes for d in n.get("domains") or []}),
+        "node_count": len(nodes),
+        "nodes": sorted(nodes, key=lambda n: n["id"]),
+        "repo": "owner/repo",
+        "version": 1,
+    }
+
+
+# ── merge_index ──────────────────────────────────────────────────────────
+
+def test_merge_index_unions_disjoint_additions():
+    base = _index([_node("a", "2026-01-01")])
+    ours = _index([_node("a", "2026-01-01"), _node("b", "2026-02-01")])
+    theirs = _index([_node("a", "2026-01-01"), _node("c", "2026-03-01")])
+    out = merge_index(base, ours, theirs)
+    assert [n["id"] for n in out["nodes"]] == ["a", "b", "c"]
+    assert out["node_count"] == 3
+
+
+def test_merge_index_collision_keeps_newer_updated_at():
+    base = _index([_node("a", "2026-01-01")])
+    ours = _index([_node("a", "2026-02-01", title="OURS")])
+    theirs = _index([_node("a", "2026-05-01", title="THEIRS")])
+    out = merge_index(base, ours, theirs)
+    assert len(out["nodes"]) == 1
+    assert out["nodes"][0]["title"] == "THEIRS"  # newer updated_at wins
+
+
+def test_merge_index_honors_deletion_when_other_side_unchanged():
+    base = _index([_node("a", "2026-01-01"), _node("x", "2026-01-01")])
+    ours = _index([_node("a", "2026-01-01"), _node("x", "2026-01-01")])  # unchanged
+    theirs = _index([_node("a", "2026-01-01")])  # deleted x
+    out = merge_index(base, ours, theirs)
+    assert [n["id"] for n in out["nodes"]] == ["a"]
+
+
+def test_merge_index_keeps_edited_node_over_delete():
+    base = _index([_node("a", "2026-01-01"), _node("x", "2026-01-01")])
+    ours = _index([_node("a", "2026-01-01"), _node("x", "2026-09-01", title="EDITED")])
+    theirs = _index([_node("a", "2026-01-01")])  # deleted x, but ours edited it
+    out = merge_index(base, ours, theirs)
+    ids = {n["id"]: n for n in out["nodes"]}
+    assert "x" in ids and ids["x"]["title"] == "EDITED"
+
+
+def test_merge_index_recomputes_header_and_drops_volatile_field():
+    ours = _index([_node("a", "2026-01-01", domains=["x"])])
+    theirs = _index([_node("b", "2026-02-01", domains=["y"])])
+    out = merge_index(None, ours, theirs)
+    assert out["domains"] == ["x", "y"]
+    assert out["node_count"] == 2
+    assert "source_updated_at" not in out
+    assert set(out) == {"domains", "node_count", "nodes", "repo", "version"}
+
+
+def test_merge_index_is_idempotent_on_unchanged_doc():
+    """Merging an unchanged canonical doc against itself yields no diff."""
+    doc = _index([_node("a", "2026-01-01", domains=["d1"]),
+                  _node("b", "2026-02-01", domains=["d2"])])
+    assert dumps_kin(merge_index(doc, doc, doc)) == dumps_kin(doc)
+
+
+def test_merge_index_preserves_write_kin_index_node_shape():
+    """Merged node entries keep the exact shape write_kin_index emits."""
+    from kindex.ingest import _kin_index_node
+    sample = _kin_index_node({
+        "id": "n", "title": "N", "type": "concept",
+        "domains": ["d"], "weight": 0.5, "updated_at": "2026-01-01",
+    })
+    out = merge_index(None, _index([sample]), None)
+    assert set(out["nodes"][0]) == set(sample)
+
+
+# ── merge_code_map ───────────────────────────────────────────────────────
+
+def _code_map(nodes, edges=None, layers=None, langs=None):
+    return {
+        "version": 1,
+        "project": {"name": "p", "languages": sorted(langs or []), "gitCommitHash": "abc"},
+        "nodes": nodes,
+        "edges": edges or [],
+        "layers": layers or [],
+        "tour": [],
+    }
+
+
+def test_merge_code_map_unions_nodes_edges_and_layer_members():
+    ours = _code_map(
+        nodes=[{"id": "m1", "filePath": "a.py"}],
+        edges=[{"source": "m1", "target": "m2", "type": "imports"}],
+        layers=[{"id": "L", "name": "Core", "nodeIds": ["m1"]}],
+        langs=["python"],
+    )
+    theirs = _code_map(
+        nodes=[{"id": "m1", "filePath": "a.py"}, {"id": "m2", "filePath": "b.py"}],
+        edges=[{"source": "m1", "target": "m3", "type": "imports"}],
+        layers=[{"id": "L", "name": "Core", "nodeIds": ["m2"]}],
+        langs=["python", "rust"],
+    )
+    out = merge_code_map(None, ours, theirs)
+    assert {n["id"] for n in out["nodes"]} == {"m1", "m2"}
+    assert len(out["edges"]) == 2
+    layer = next(l for l in out["layers"] if l["id"] == "L")
+    assert layer["nodeIds"] == ["m1", "m2"]  # member union, restricted to present nodes
+    assert out["project"]["languages"] == ["python", "rust"]
+    assert out["tour"][0]["order"] == 1  # tour recomputed from merged layers
+
+
+def test_merge_code_map_round_trips_canonical_bytes():
+    """A canonical code-map merged against itself is byte-identical (no regen churn).
+
+    Mirrors `kin export code-map`: nodes ordered by (filePath, type, id), no
+    sort_keys, insertion-order keys preserved.
+    """
+    doc = {
+        "version": 1,
+        "project": {
+            "name": "p", "description": "d", "languages": ["python"],
+            "frameworks": [], "analyzedAt": "t", "gitCommitHash": "h",
+        },
+        "nodes": [
+            {"id": "m1", "type": "module", "name": "A", "filePath": "a.py",
+             "summary": "", "tags": [], "complexity": 1},
+            {"id": "m2", "type": "module", "name": "B", "filePath": "b.py",
+             "summary": "", "tags": [], "complexity": 1},
+        ],
+        "edges": [{"source": "m1", "target": "m2", "type": "imports"}],
+        "layers": [{"id": "L", "name": "Core", "nodeIds": ["m1", "m2"]}],
+        "tour": [{"order": 1, "title": "Core",
+                  "description": "Review 2 node(s) in the Core layer.",
+                  "nodeIds": ["m1", "m2"]}],
+    }
+    assert dumps_code_map(merge_code_map(None, doc, doc)) == dumps_code_map(doc)
+
+
+# ── load_json / merge_for / merge_kin_files ─────────────────────────────
+
+def test_load_json_handles_empty_missing_and_invalid(tmp_path):
+    assert load_json(tmp_path / "nope.json") is None  # missing
+    empty = tmp_path / "empty.json"
+    empty.write_text("   \n")
+    assert load_json(empty) is None  # empty -> absent side
+    bad = tmp_path / "bad.json"
+    bad.write_text("{not json")
+    with pytest.raises(ValueError):
+        load_json(bad)
+
+
+def test_merge_for_declines_unknown_filename():
+    assert merge_for("something-else.json", None, {}, {}) is None
+    assert merge_for(".kin/index.json", None, _index([]), _index([])) is not None
+
+
+def test_merge_kin_files_end_to_end_for_index(tmp_path):
+    base = tmp_path / "base"; ours = tmp_path / "ours"; theirs = tmp_path / "theirs"
+    base.write_text(dumps_kin(_index([_node("a", "2026-01-01")])))
+    ours.write_text(dumps_kin(_index([_node("a", "2026-01-01"), _node("b", "2026-02-01")])))
+    theirs.write_text(dumps_kin(_index([_node("a", "2026-01-01"), _node("c", "2026-03-01")])))
+    merged = merge_kin_files(".kin/index.json", str(base), str(ours), str(theirs))
+    assert merged is not None
+    ids = [n["id"] for n in json.loads(merged)["nodes"]]
+    assert ids == ["a", "b", "c"]
+
+
+def test_merge_kin_files_declines_unknown_path(tmp_path):
+    f = tmp_path / "f.json"; f.write_text("{}")
+    assert merge_kin_files("README.md", str(f), str(f), str(f)) is None
+
+
+# ── real git merge with the driver registered (the proof) ───────────────
+
+def _git(repo, *args):
+    return subprocess.run(["git", "-C", str(repo), *args],
+                          capture_output=True, text=True, timeout=30)
+
+
+@pytest.mark.skipif(
+    subprocess.run(["which", "git"], capture_output=True).returncode != 0,
+    reason="git not available",
+)
+def test_git_merge_resolves_via_driver(tmp_path):
+    repo = tmp_path / "repo"
+    (repo / ".kin").mkdir(parents=True)
+    _git(repo, "init", "-q")
+    _git(repo, "config", "user.email", "t@t.t")
+    _git(repo, "config", "user.name", "T")
+    driver = f"{sys.executable} -m kindex.cli merge-kin %O %A %B %P"
+    _git(repo, "config", "merge.kindex.driver", driver)
+    (repo / ".gitattributes").write_text(".kin/index.json merge=kindex\n")
+    idx = repo / ".kin" / "index.json"
+
+    idx.write_text(dumps_kin(_index([_node("a", "2026-01-01")])))
+    _git(repo, "add", "-A"); _git(repo, "commit", "-qm", "base")
+    default_branch = _git(repo, "branch", "--show-current").stdout.strip() or "master"
+
+    _git(repo, "checkout", "-qb", "feature")
+    idx.write_text(dumps_kin(_index([_node("a", "2026-01-01"), _node("b", "2026-02-01")])))
+    _git(repo, "add", "-A"); _git(repo, "commit", "-qm", "add b")
+
+    _git(repo, "checkout", "-q", default_branch)
+    idx.write_text(dumps_kin(_index([_node("a", "2026-01-01"), _node("c", "2026-03-01")])))
+    _git(repo, "add", "-A"); _git(repo, "commit", "-qm", "add c")
+
+    result = _git(repo, "merge", "--no-edit", "feature")
+    assert result.returncode == 0, f"merge failed: {result.stdout}\n{result.stderr}"
+    text = idx.read_text()
+    assert "<<<<<<<" not in text  # no conflict markers
+    ids = [n["id"] for n in json.loads(text)["nodes"]]
+    assert ids == ["a", "b", "c"]  # lossless union, both sides preserved
+
+
+@pytest.mark.skipif(
+    subprocess.run(["which", "git"], capture_output=True).returncode != 0,
+    reason="git not available",
+)
+def test_setup_merge_driver_install_is_idempotent_and_reversible(tmp_path):
+    from kindex.setup import (
+        git_repo_root, install_merge_driver, uninstall_merge_driver,
+    )
+    repo = tmp_path / "r"; repo.mkdir()
+    _git(repo, "init", "-q")
+    root = git_repo_root(repo)
+    assert root is not None
+
+    install_merge_driver(root)
+    assert "merge-kin %O %A %B %P" in _git(repo, "config", "merge.kindex.driver").stdout
+    attrs = (repo / ".gitattributes").read_text()
+    assert ".kin/index.json merge=kindex" in attrs
+    assert ".kin/code-map.json merge=kindex" in attrs
+
+    install_merge_driver(root)  # idempotent — no duplicate lines
+    assert (repo / ".gitattributes").read_text().count("index.json merge=kindex") == 1
+
+    uninstall_merge_driver(root)
+    assert _git(repo, "config", "merge.kindex.driver").returncode != 0
+    assert "merge=kindex" not in (repo / ".gitattributes").read_text()

--- a/tests/test_new_features.py
+++ b/tests/test_new_features.py
@@ -373,9 +373,10 @@ class TestKinIndex:
         assert node_ids == sorted(node_ids)
         assert data["domains"] == sorted(data["domains"])
         assert "generated_at" not in data
-        assert data["source_updated_at"] == max(
-            node["updated_at"] for node in data["nodes"]
-        )
+        # No volatile timestamp in the committed snapshot (would churn git history
+        # and conflict on every concurrent merge); per-node updated_at is enough.
+        assert "source_updated_at" not in data
+        assert all("updated_at" in node for node in data["nodes"])
 
 
 # ── 6. Analytics module ──────────────────────────────────────────────


### PR DESCRIPTION
## Summary

A `kin merge-kin` git **merge driver** so the generated, id-keyed `.kin` artifacts stop producing git conflicts — a structured 3-way union, not a manual resolver.

- **`index.json`** — union nodes by id (newer `updated_at` wins; base detects deletions), recompute the derived header. This is **lossless across machines**: `index.json` projects the local SQLite DB (not in git), so regenerating from one machine's DB would silently drop the other branch's concept/decision nodes. Output is **byte-identical** to a fresh `kin index`, so a later regeneration yields no diff.
- **`code-map.json`** — union nodes/edges/layer-members, recompute the tour. Serialized to match `kin export code-map` exactly (node order `(filePath, type, id)`, no `sort_keys`), so a regeneration also yields no diff.
- **`kin setup-merge`** registers the driver in the repo's `.git/config` and points the `.kin` artifacts at it via `.gitattributes` (idempotent, reversible). Repos without it registered fall back to git's default merge.
- Drops the volatile `source_updated_at` from `index.json` — it changed on every regeneration (churning history, conflicting on every concurrent merge), while the commit time already records freshness and each node keeps its own `updated_at`.

## Why a union, not "regenerate the whole thing"

`index.json` projects the local DB, which isn't in git — regenerate-from-DB is lossy across machines. The files are sorted, id-keyed node lists with per-node `updated_at`, so a structured union is the lossless, format-native merge. `code-map.json` projects the code (which *is* in the tree), but in-driver regeneration is fragile mid-merge, so it's unioned too; `kin export code-map` remains the canonical refresh.

## Review

An adversarial pass returned **ship**; its one real finding — code-map merge output didn't match the canonical exporter's format (would churn on the next regen) — is fixed here (per-file serializer + node ordering, with a byte-identity test). Four nits also addressed (docstring, dead `_latest_node_time`, tie-break doc, uninstall returncode).

## Tests

**1540 pass** (+15 new), including a **real `git merge`** that proves lossless, conflict-free resolution, a code-map byte-identity round-trip, and setup-driver idempotency/reversibility.

Version → **0.26.0** (new feature).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
