### PR TITLE
Prevent git probes from inheriting MCP stdin

### DIFF
--- a/src/kindex/config.py
+++ b/src/kindex/config.py
@@ -493,9 +493,12 @@ def _detect_user(project_path: str | Path | None = None) -> str:
 
     for command in commands:
         try:
+            # Config probes may run inside stdio MCP servers; never let child
+            # Git processes inherit the JSON-RPC stdin pipe.
             result = subprocess.run(
                 command,
                 capture_output=True, text=True, timeout=2,
+                stdin=subprocess.DEVNULL,
             )
             if result.returncode == 0 and result.stdout.strip():
                 return result.stdout.strip().lower().replace(" ", "-")
@@ -687,10 +690,13 @@ def resolve_project_root(project_path: str | Path | None = None) -> Path:
 def _git_root(start: Path) -> Path | None:
     import subprocess
     try:
+        # Config probes may run inside stdio MCP servers; never let child
+        # Git processes inherit the JSON-RPC stdin pipe.
         result = subprocess.run(
             ["git", "-C", str(start), "rev-parse", "--show-toplevel"],
             capture_output=True,
             text=True,
+            stdin=subprocess.DEVNULL,
             timeout=3,
         )
     except (FileNotFoundError, subprocess.TimeoutExpired):


### PR DESCRIPTION
## Summary

detach Kindex's Git config/root probes from process stdin


## Why

When `kin-mcp` runs over stdio, config resolution may invoke `git` while handling the first MCP tool call. Without an explicit stdin redirect, the Git subprocess can inherit the MCP server's JSON-RPC stdin pipe. On Windows this reproduced as `tools/call` stalling while config loading waited inside `subprocess.run(...)`.

Redirecting those Git probes to `subprocess.DEVNULL` keeps child Git processes from reading or holding the MCP transport.

## Validation

- Reproduced the `kin-mcp` stall locally on Windows: MCP initialization and `tools/list` succeeded, but the first `tools/call` hung while config resolution was waiting inside a Git subprocess.
- Applied the same `stdin=subprocess.DEVNULL` change locally and verified the issue was resolved: `status`, `tag_start`, and `search` all returned through MCP immediately in a disposable smoke test.
- Verified against the real local Kindex graph after the fix: MCP `status` returned in ~0.065s and MCP `search` returned in ~0.015s.
