### PR TITLE
fix: bound Dream topology and session lifecycle

### DIFF
--- a/.kin/code-map.json
+++ b/.kin/code-map.json
@@ -7,8 +7,8 @@
       "Python"
     ],
     "frameworks": [],
-    "analyzedAt": "2026-08-31T19:20:24-05:00",
-    "gitCommitHash": "7089ce594c8d996d5b88d0f3bb2f2132536452a5"
+    "analyzedAt": "2026-09-02T20:07:41-05:00",
+    "gitCommitHash": "bbd4278437f895c715e574643a3cd895c2e25476"
   },
   "nodes": [
     {
@@ -237,7 +237,7 @@
       "type": "file",
       "name": "src/kindex/archive.py",
       "filePath": "src/kindex/archive.py",
-      "summary": "Language: Python | Path: src/kindex/archive.py | ~358 lines ## Functions - archive_cycle( config: \"Config\", store: \"Store\", verbose: bool = False, ) -> int",
+      "summary": "Language: Python | Path: src/kindex/archive.py | ~461 lines ## Functions - archive_cycle( config: \"Config\", store: \"Store\", verbose: bool = False, ) -> int",
       "tags": [
         "code",
         "python"
@@ -271,7 +271,7 @@
       "type": "file",
       "name": "src/kindex/cli.py",
       "filePath": "src/kindex/cli.py",
-      "summary": "Language: Python | Path: src/kindex/cli.py | ~7516 lines ## Functions - cmd_add(args)",
+      "summary": "Language: Python | Path: src/kindex/cli.py | ~7647 lines ## Functions - cmd_add(args)",
       "tags": [
         "code",
         "python"
@@ -322,7 +322,7 @@
       "type": "class",
       "name": "ReminderConfig",
       "filePath": "src/kindex/config.py",
-      "summary": "class ReminderConfig(BaseModel) (src/kindex/config.py:547)",
+      "summary": "class ReminderConfig(BaseModel) (src/kindex/config.py:588)",
       "tags": [
         "code",
         "python"
@@ -339,7 +339,7 @@
       "type": "class",
       "name": "SimConfig",
       "filePath": "src/kindex/config.py",
-      "summary": "class SimConfig(BaseModel) (src/kindex/config.py:411)",
+      "summary": "class SimConfig(BaseModel) (src/kindex/config.py:438)",
       "tags": [
         "code",
         "python"
@@ -424,7 +424,7 @@
       "type": "class",
       "name": "ScheduleTier",
       "filePath": "src/kindex/config.py",
-      "summary": "class ScheduleTier(BaseModel) (src/kindex/config.py:534)",
+      "summary": "class ScheduleTier(BaseModel) (src/kindex/config.py:575)",
       "tags": [
         "code",
         "python"
@@ -441,7 +441,7 @@
       "type": "class",
       "name": "RankingConfig",
       "filePath": "src/kindex/config.py",
-      "summary": "class RankingConfig(BaseModel) (src/kindex/config.py:453) ## Methods - ensemble_weights(self) -> dict[str,float]",
+      "summary": "class RankingConfig(BaseModel) (src/kindex/config.py:494) ## Methods - ensemble_weights(self) -> dict[str,float]",
       "tags": [
         "code",
         "python"
@@ -458,7 +458,7 @@
       "type": "class",
       "name": "WorkPolicyConfig",
       "filePath": "src/kindex/config.py",
-      "summary": "class WorkPolicyConfig(BaseModel) (src/kindex/config.py:590)",
+      "summary": "class WorkPolicyConfig(BaseModel) (src/kindex/config.py:632)",
       "tags": [
         "code",
         "python"
@@ -475,7 +475,7 @@
       "type": "class",
       "name": "ClaudeChannelConfig",
       "filePath": "src/kindex/config.py",
-      "summary": "class ClaudeChannelConfig(BaseModel) (src/kindex/config.py:513)",
+      "summary": "class ClaudeChannelConfig(BaseModel) (src/kindex/config.py:554)",
       "tags": [
         "code",
         "python"
@@ -492,7 +492,7 @@
       "type": "class",
       "name": "Config",
       "filePath": "src/kindex/config.py",
-      "summary": "class Config(BaseModel) (src/kindex/config.py:609) ## Methods - antigravity_cli_path(self) -> Path",
+      "summary": "class Config(BaseModel) (src/kindex/config.py:651) ## Methods - antigravity_cli_path(self) -> Path",
       "tags": [
         "code",
         "python"
@@ -509,7 +509,7 @@
       "type": "class",
       "name": "TelegramChannelConfig",
       "filePath": "src/kindex/config.py",
-      "summary": "class TelegramChannelConfig(BaseModel) (src/kindex/config.py:519)",
+      "summary": "class TelegramChannelConfig(BaseModel) (src/kindex/config.py:560)",
       "tags": [
         "code",
         "python"
@@ -526,7 +526,7 @@
       "type": "class",
       "name": "SystemChannelConfig",
       "filePath": "src/kindex/config.py",
-      "summary": "class SystemChannelConfig(BaseModel) (src/kindex/config.py:493)",
+      "summary": "class SystemChannelConfig(BaseModel) (src/kindex/config.py:534)",
       "tags": [
         "code",
         "python"
@@ -543,7 +543,7 @@
       "type": "class",
       "name": "SlackChannelConfig",
       "filePath": "src/kindex/config.py",
-      "summary": "class SlackChannelConfig(BaseModel) (src/kindex/config.py:498)",
+      "summary": "class SlackChannelConfig(BaseModel) (src/kindex/config.py:539)",
       "tags": [
         "code",
         "python"
@@ -560,7 +560,7 @@
       "type": "class",
       "name": "EmailChannelConfig",
       "filePath": "src/kindex/config.py",
-      "summary": "class EmailChannelConfig(BaseModel) (src/kindex/config.py:503)",
+      "summary": "class EmailChannelConfig(BaseModel) (src/kindex/config.py:544)",
       "tags": [
         "code",
         "python"
@@ -594,7 +594,7 @@
       "type": "class",
       "name": "LinearPolicyConfig",
       "filePath": "src/kindex/config.py",
-      "summary": "class LinearPolicyConfig(BaseModel) (src/kindex/config.py:577)",
+      "summary": "class LinearPolicyConfig(BaseModel) (src/kindex/config.py:619)",
       "tags": [
         "code",
         "python"
@@ -611,7 +611,7 @@
       "type": "class",
       "name": "DefaultsConfig",
       "filePath": "src/kindex/config.py",
-      "summary": "class DefaultsConfig(BaseModel) (src/kindex/config.py:487)",
+      "summary": "class DefaultsConfig(BaseModel) (src/kindex/config.py:528)",
       "tags": [
         "code",
         "python"
@@ -645,7 +645,24 @@
       "type": "class",
       "name": "GitPolicyConfig",
       "filePath": "src/kindex/config.py",
-      "summary": "class GitPolicyConfig(BaseModel) (src/kindex/config.py:583)",
+      "summary": "class GitPolicyConfig(BaseModel) (src/kindex/config.py:625)",
+      "tags": [
+        "code",
+        "python"
+      ],
+      "complexity": 1,
+      "languageNotes": {
+        "language": "Python",
+        "kindexType": "concept",
+        "toolTier": ""
+      }
+    },
+    {
+      "id": "code-sym-kindex-db305b174dc2",
+      "type": "class",
+      "name": "AdvocateConfig",
+      "filePath": "src/kindex/config.py",
+      "summary": "class AdvocateConfig(BaseModel) (src/kindex/config.py:411)",
       "tags": [
         "code",
         "python"
@@ -662,7 +679,7 @@
       "type": "class",
       "name": "ChannelsConfig",
       "filePath": "src/kindex/config.py",
-      "summary": "class ChannelsConfig(BaseModel) (src/kindex/config.py:526)",
+      "summary": "class ChannelsConfig(BaseModel) (src/kindex/config.py:567)",
       "tags": [
         "code",
         "python"
@@ -679,12 +696,12 @@
       "type": "file",
       "name": "src/kindex/config.py",
       "filePath": "src/kindex/config.py",
-      "summary": "Language: Python | Path: src/kindex/config.py | ~1323 lines ## Classes - AgentInstanceConfig(AgentOverrideConfig)",
+      "summary": "Language: Python | Path: src/kindex/config.py | ~1365 lines ## Classes - AdvocateConfig(BaseModel)",
       "tags": [
         "code",
         "python"
       ],
-      "complexity": 60,
+      "complexity": 61,
       "languageNotes": {
         "language": "Python",
         "kindexType": "artifact",
@@ -696,7 +713,7 @@
       "type": "file",
       "name": "src/kindex/daemon.py",
       "filePath": "src/kindex/daemon.py",
-      "summary": "Language: Python | Path: src/kindex/daemon.py | ~857 lines ## Functions - cron_run(config: \"Config\", store: \"Store\", verbose: bool = False) -> dict",
+      "summary": "Language: Python | Path: src/kindex/daemon.py | ~860 lines ## Functions - cron_run(config: \"Config\", store: \"Store\", verbose: bool = False) -> dict",
       "tags": [
         "code",
         "python"
@@ -713,7 +730,7 @@
       "type": "file",
       "name": "src/kindex/dream.py",
       "filePath": "src/kindex/dream.py",
-      "summary": "Language: Python | Path: src/kindex/dream.py | ~670 lines ## Functions - auto_apply_suggestions(store: Store) -> int",
+      "summary": "Language: Python | Path: src/kindex/dream.py | ~748 lines ## Functions - auto_apply_suggestions(store: Store) -> int",
       "tags": [
         "code",
         "python"
@@ -730,12 +747,12 @@
       "type": "file",
       "name": "src/kindex/dream_deep.py",
       "filePath": "src/kindex/dream_deep.py",
-      "summary": "Language: Python | Path: src/kindex/dream_deep.py | ~161 lines ## Functions - dream_deep( config: Config, store: Store, *, verbose: bool = False, dry_run: bool = False, timeout: int = 300, ) -> dict",
+      "summary": "Language: Python | Path: src/kindex/dream_deep.py | ~300 lines ## Functions - dream_deep( config: Config, store: Store, *, verbose: bool = False, dry_run: bool = False, timeout: int = 300, ) -> dict",
       "tags": [
         "code",
         "python"
       ],
-      "complexity": 4,
+      "complexity": 7,
       "languageNotes": {
         "language": "Python",
         "kindexType": "artifact",
@@ -900,7 +917,7 @@
       "type": "file",
       "name": "src/kindex/graph.py",
       "filePath": "src/kindex/graph.py",
-      "summary": "Language: Python | Path: src/kindex/graph.py | ~443 lines ## Classes - GraphStats",
+      "summary": "Language: Python | Path: src/kindex/graph.py | ~476 lines ## Classes - GraphStats",
       "tags": [
         "code",
         "python"
@@ -968,7 +985,7 @@
       "type": "file",
       "name": "src/kindex/hooks.py",
       "filePath": "src/kindex/hooks.py",
-      "summary": "Language: Python | Path: src/kindex/hooks.py | ~690 lines ## Functions - capture_session_end( store: Store, config: Config, ledger: BudgetLedger, session_text: str | None = None, ) -> int",
+      "summary": "Language: Python | Path: src/kindex/hooks.py | ~695 lines ## Functions - capture_session_end( store: Store, config: Config, ledger: BudgetLedger, session_text: str | None = None, ) -> int",
       "tags": [
         "code",
         "python"
@@ -1036,7 +1053,7 @@
       "type": "file",
       "name": "src/kindex/mcp_server.py",
       "filePath": "src/kindex/mcp_server.py",
-      "summary": "Language: Python | Path: src/kindex/mcp_server.py | ~2681 lines ## Classes - MemoryUnavailableError(RuntimeError)",
+      "summary": "Language: Python | Path: src/kindex/mcp_server.py | ~2759 lines ## Classes - MemoryUnavailableError(RuntimeError)",
       "tags": [
         "code",
         "python"
@@ -1206,7 +1223,7 @@
       "type": "file",
       "name": "src/kindex/retrieve.py",
       "filePath": "src/kindex/retrieve.py",
-      "summary": "Language: Python | Path: src/kindex/retrieve.py | ~1328 lines ## Functions - auto_select_tier(available_tokens: int | None = None) -> str",
+      "summary": "Language: Python | Path: src/kindex/retrieve.py | ~1330 lines ## Functions - auto_select_tier(available_tokens: int | None = None) -> str",
       "tags": [
         "code",
         "python"
@@ -1240,7 +1257,7 @@
       "type": "file",
       "name": "src/kindex/schema.py",
       "filePath": "src/kindex/schema.py",
-      "summary": "Language: Python | Path: src/kindex/schema.py | ~302 lines ## Functions - edit_class_for(node_type: str, overrides: dict[str, str] | None = None) -> str",
+      "summary": "Language: Python | Path: src/kindex/schema.py | ~321 lines ## Functions - edit_class_for(node_type: str, overrides: dict[str, str] | None = None) -> str",
       "tags": [
         "code",
         "python"
@@ -1257,12 +1274,12 @@
       "type": "file",
       "name": "src/kindex/sessions.py",
       "filePath": "src/kindex/sessions.py",
-      "summary": "Language: Python | Path: src/kindex/sessions.py | ~526 lines ## Functions - add_segment( store: Store, name: str, *, new_focus: str, summary: str = \"\", decisions: list[str] | None = None, ) -> None",
+      "summary": "Language: Python | Path: src/kindex/sessions.py | ~593 lines ## Functions - add_segment( store: Store, name: str, *, new_focus: str, summary: str = \"\", decisions: list[str] | None = None, project_path: str | None = None, ) -> None",
       "tags": [
         "code",
         "python"
       ],
-      "complexity": 12,
+      "complexity": 13,
       "languageNotes": {
         "language": "Python",
         "kindexType": "artifact",
@@ -1274,12 +1291,12 @@
       "type": "file",
       "name": "src/kindex/setup.py",
       "filePath": "src/kindex/setup.py",
-      "summary": "Language: Python | Path: src/kindex/setup.py | ~1263 lines ## Functions - git_repo_root(start: \"str | Path | None\" = None) -> \"Path | None\"",
+      "summary": "Language: Python | Path: src/kindex/setup.py | ~1343 lines ## Functions - git_repo_root(start: \"str | Path | None\" = None) -> \"Path | None\"",
       "tags": [
         "code",
         "python"
       ],
-      "complexity": 40,
+      "complexity": 42,
       "languageNotes": {
         "language": "Python",
         "kindexType": "artifact",
@@ -1308,12 +1325,12 @@
       "type": "class",
       "name": "Store",
       "filePath": "src/kindex/store.py",
-      "summary": "class Store (src/kindex/store.py:250) ## Methods - accept_capture_candidate( self, candidate_id: str, *, review_token: str, reviewed_by: str, prov_method: str, valid_at: str | None = None, invalid_at: str | None = None, now: str | None = None, ) -> dict",
+      "summary": "class Store (src/kindex/store.py:273) ## Methods - accept_capture_candidate( self, candidate_id: str, *, review_token: str, reviewed_by: str, prov_method: str, valid_at: str | None = None, invalid_at: str | None = None, now: str | None = None, ) -> dict",
       "tags": [
         "code",
         "python"
       ],
-      "complexity": 74,
+      "complexity": 75,
       "languageNotes": {
         "language": "Python",
         "kindexType": "concept",
@@ -1325,7 +1342,7 @@
       "type": "file",
       "name": "src/kindex/store.py",
       "filePath": "src/kindex/store.py",
-      "summary": "Language: Python | Path: src/kindex/store.py | ~3725 lines ## Classes - CandidateNotFoundError(ValueError)",
+      "summary": "Language: Python | Path: src/kindex/store.py | ~3994 lines ## Classes - CandidateNotFoundError(ValueError)",
       "tags": [
         "code",
         "python"
@@ -1342,7 +1359,7 @@
       "type": "file",
       "name": "src/kindex/tasks.py",
       "filePath": "src/kindex/tasks.py",
-      "summary": "Language: Python | Path: src/kindex/tasks.py | ~463 lines ## Functions - cancel_task(store: Store, task_id: str) -> dict|None",
+      "summary": "Language: Python | Path: src/kindex/tasks.py | ~486 lines ## Functions - cancel_task(store: Store, task_id: str) -> dict|None",
       "tags": [
         "code",
         "python"
@@ -1762,6 +1779,13 @@
       "weight": 0.01
     },
     {
+      "source": "code-sym-kindex-db305b174dc2",
+      "target": "code-mod-kindex-6a3142a46050",
+      "type": "contains",
+      "direction": "outbound",
+      "weight": 0.6
+    },
+    {
       "source": "code-sym-kindex-e0501acf75b6",
       "target": "code-mod-kindex-9865e2d9ecc1",
       "type": "contains",
@@ -1875,6 +1899,7 @@
         "code-sym-kindex-b90676bdf42f",
         "code-sym-kindex-c644dbd33873",
         "code-sym-kindex-cbab8b0e1faf",
+        "code-sym-kindex-db305b174dc2",
         "code-sym-kindex-e0501acf75b6",
         "code-sym-kindex-fe4d5554b184"
       ]
@@ -1925,7 +1950,7 @@
     {
       "order": 3,
       "title": "Domain",
-      "description": "Review 39 node(s) in the Domain layer.",
+      "description": "Review 40 node(s) in the Domain layer.",
       "nodeIds": [
         "code-sym-kindex-05a1fbf0db2e",
         "code-sym-kindex-0707d0c210b4",

--- a/.kin/config
+++ b/.kin/config
@@ -30,7 +30,7 @@ voice:
 
 standards:
   code_review:
-    - 1927 tests, all must pass
+    - 1987 tests, all must pass
     - Pydantic models for all data structures
     - SQLite migrations are forward-only, atomic, and verify COLUMNS not just tables
     - MCP tools match CLI capabilities

--- a/.kin/index.json
+++ b/.kin/index.json
@@ -4,7 +4,7 @@
     "python",
     "shell"
   ],
-  "node_count": 150,
+  "node_count": 151,
   "nodes": [
     {
       "domains": [
@@ -102,7 +102,7 @@
       "id": "code-mod-kindex-1668da8a23a5",
       "title": "src/kindex/daemon.py",
       "type": "artifact",
-      "updated_at": "2026-08-31T18:00:39",
+      "updated_at": "2026-09-02T20:07:06",
       "weight": 0.01
     },
     {
@@ -157,7 +157,7 @@
       "id": "code-mod-kindex-1cc1824729d5",
       "title": "src/kindex/ingest.py",
       "type": "artifact",
-      "updated_at": "2026-08-31T18:00:39",
+      "updated_at": "2026-09-02T20:07:06",
       "weight": 0.01
     },
     {
@@ -190,7 +190,7 @@
       "id": "code-mod-kindex-26bb9b6e1fcb",
       "title": "src/kindex/graph.py",
       "type": "artifact",
-      "updated_at": "2026-05-24T14:04:23",
+      "updated_at": "2026-09-02T20:07:06",
       "weight": 0.01
     },
     {
@@ -212,7 +212,7 @@
       "id": "code-mod-kindex-2fcd370316b8",
       "title": "src/kindex/sim.py",
       "type": "artifact",
-      "updated_at": "2026-06-11T15:16:38",
+      "updated_at": "2026-09-02T20:07:06",
       "weight": 0.01
     },
     {
@@ -256,7 +256,7 @@
       "id": "code-mod-kindex-46a31493a160",
       "title": "src/kindex/store.py",
       "type": "artifact",
-      "updated_at": "2026-08-31T18:00:39",
+      "updated_at": "2026-09-02T20:07:06",
       "weight": 0.01
     },
     {
@@ -311,7 +311,7 @@
       "id": "code-mod-kindex-5aa57e096c49",
       "title": "src/kindex/dream.py",
       "type": "artifact",
-      "updated_at": "2026-08-31T18:00:39",
+      "updated_at": "2026-09-02T20:07:06",
       "weight": 0.01
     },
     {
@@ -322,7 +322,7 @@
       "id": "code-mod-kindex-62731532a556",
       "title": "src/kindex/setup.py",
       "type": "artifact",
-      "updated_at": "2026-08-31T18:00:39",
+      "updated_at": "2026-09-02T20:07:06",
       "weight": 0.01
     },
     {
@@ -333,7 +333,7 @@
       "id": "code-mod-kindex-66df7720eed6",
       "title": "src/kindex/cli.py",
       "type": "artifact",
-      "updated_at": "2026-08-31T18:00:39",
+      "updated_at": "2026-09-02T20:07:06",
       "weight": 0.01
     },
     {
@@ -344,7 +344,7 @@
       "id": "code-mod-kindex-6a3142a46050",
       "title": "src/kindex/config.py",
       "type": "artifact",
-      "updated_at": "2026-08-31T18:00:39",
+      "updated_at": "2026-09-02T20:07:06",
       "weight": 0.01
     },
     {
@@ -366,7 +366,7 @@
       "id": "code-mod-kindex-702e4442e57e",
       "title": "src/kindex/tasks.py",
       "type": "artifact",
-      "updated_at": "2026-06-12T11:32:26",
+      "updated_at": "2026-09-02T20:07:06",
       "weight": 0.01
     },
     {
@@ -410,7 +410,7 @@
       "id": "code-mod-kindex-7e3e66278abe",
       "title": "src/kindex/archive.py",
       "type": "artifact",
-      "updated_at": "2026-06-12T11:32:26",
+      "updated_at": "2026-09-02T20:07:06",
       "weight": 0.01
     },
     {
@@ -531,7 +531,7 @@
       "id": "code-mod-kindex-b568a48e00e4",
       "title": "src/kindex/dream_deep.py",
       "type": "artifact",
-      "updated_at": "2026-03-27T22:16:52",
+      "updated_at": "2026-09-02T20:07:06",
       "weight": 0.01
     },
     {
@@ -553,7 +553,7 @@
       "id": "code-mod-kindex-bd222a4e378f",
       "title": "src/kindex/hooks.py",
       "type": "artifact",
-      "updated_at": "2026-08-31T18:00:39",
+      "updated_at": "2026-09-02T20:07:06",
       "weight": 0.01
     },
     {
@@ -586,7 +586,7 @@
       "id": "code-mod-kindex-c4522229e518",
       "title": "src/kindex/__init__.py",
       "type": "artifact",
-      "updated_at": "2026-08-31T18:00:39",
+      "updated_at": "2026-09-02T20:07:06",
       "weight": 0.01
     },
     {
@@ -597,7 +597,7 @@
       "id": "code-mod-kindex-c77f7cec7d57",
       "title": "src/kindex/sessions.py",
       "type": "artifact",
-      "updated_at": "2026-08-31T18:00:39",
+      "updated_at": "2026-09-02T20:07:06",
       "weight": 0.01
     },
     {
@@ -608,7 +608,7 @@
       "id": "code-mod-kindex-c8ebc72bbedb",
       "title": "src/kindex/schema.py",
       "type": "artifact",
-      "updated_at": "2026-08-31T18:00:39",
+      "updated_at": "2026-09-02T20:07:06",
       "weight": 0.01
     },
     {
@@ -641,7 +641,7 @@
       "id": "code-mod-kindex-d68e56207179",
       "title": "src/kindex/retrieve.py",
       "type": "artifact",
-      "updated_at": "2026-08-31T18:00:39",
+      "updated_at": "2026-09-02T20:07:06",
       "weight": 0.01
     },
     {
@@ -663,7 +663,7 @@
       "id": "code-mod-kindex-e381cc44d87c",
       "title": "src/kindex/code_map.py",
       "type": "artifact",
-      "updated_at": "2026-08-31T18:00:39",
+      "updated_at": "2026-09-02T20:07:06",
       "weight": 0.01
     },
     {
@@ -696,7 +696,7 @@
       "id": "code-mod-kindex-f9986c492ab2",
       "title": "src/kindex/mcp_server.py",
       "type": "artifact",
-      "updated_at": "2026-08-31T18:00:39",
+      "updated_at": "2026-09-02T20:07:06",
       "weight": 0.01
     },
     {
@@ -729,7 +729,7 @@
       "id": "code-sym-kindex-05a1fbf0db2e",
       "title": "AgentsConfig",
       "type": "concept",
-      "updated_at": "2026-08-31T18:00:39",
+      "updated_at": "2026-09-02T20:07:06",
       "weight": 0.5
     },
     {
@@ -751,7 +751,7 @@
       "id": "code-sym-kindex-0850aa56538b",
       "title": "ProfileEntry",
       "type": "concept",
-      "updated_at": "2026-08-31T18:00:39",
+      "updated_at": "2026-09-02T20:07:06",
       "weight": 0.5
     },
     {
@@ -762,7 +762,7 @@
       "id": "code-sym-kindex-08e1ea9d3cda",
       "title": "ReminderConfig",
       "type": "concept",
-      "updated_at": "2026-08-31T18:00:39",
+      "updated_at": "2026-09-02T20:07:06",
       "weight": 0.5
     },
     {
@@ -828,7 +828,7 @@
       "id": "code-sym-kindex-15261553fafb",
       "title": "SimConfig",
       "type": "concept",
-      "updated_at": "2026-08-31T18:00:39",
+      "updated_at": "2026-09-02T20:07:06",
       "weight": 0.5
     },
     {
@@ -916,7 +916,7 @@
       "id": "code-sym-kindex-200aad86be36",
       "title": "AttentionConfig",
       "type": "concept",
-      "updated_at": "2026-08-31T18:00:39",
+      "updated_at": "2026-09-02T20:07:06",
       "weight": 0.5
     },
     {
@@ -938,7 +938,7 @@
       "id": "code-sym-kindex-219563924e7c",
       "title": "GroundingConfig",
       "type": "concept",
-      "updated_at": "2026-08-31T18:00:39",
+      "updated_at": "2026-09-02T20:07:06",
       "weight": 0.5
     },
     {
@@ -949,7 +949,7 @@
       "id": "code-sym-kindex-279e1c45cb06",
       "title": "AgentInstanceConfig",
       "type": "concept",
-      "updated_at": "2026-08-31T18:00:39",
+      "updated_at": "2026-09-02T20:07:06",
       "weight": 0.5
     },
     {
@@ -982,7 +982,7 @@
       "id": "code-sym-kindex-352d8c9bbdba",
       "title": "CollabConfig",
       "type": "concept",
-      "updated_at": "2026-08-31T18:00:39",
+      "updated_at": "2026-09-02T20:07:06",
       "weight": 0.5
     },
     {
@@ -993,7 +993,7 @@
       "id": "code-sym-kindex-36fe0270bb97",
       "title": "ScheduleTier",
       "type": "concept",
-      "updated_at": "2026-08-31T18:00:39",
+      "updated_at": "2026-09-02T20:07:06",
       "weight": 0.5
     },
     {
@@ -1004,7 +1004,7 @@
       "id": "code-sym-kindex-3da712cdf5b5",
       "title": "MemoryUnavailableError",
       "type": "concept",
-      "updated_at": "2026-08-31T18:45:07",
+      "updated_at": "2026-09-02T20:07:06",
       "weight": 0.01
     },
     {
@@ -1015,7 +1015,7 @@
       "id": "code-sym-kindex-415d46d7c508",
       "title": "RankingConfig",
       "type": "concept",
-      "updated_at": "2026-08-31T18:00:39",
+      "updated_at": "2026-09-02T20:07:06",
       "weight": 0.5
     },
     {
@@ -1026,7 +1026,7 @@
       "id": "code-sym-kindex-4710515cacde",
       "title": "InvalidIntervalError",
       "type": "concept",
-      "updated_at": "2026-08-31T18:45:07",
+      "updated_at": "2026-09-02T20:07:06",
       "weight": 0.01
     },
     {
@@ -1081,7 +1081,7 @@
       "id": "code-sym-kindex-552c22e16187",
       "title": "WorkPolicyConfig",
       "type": "concept",
-      "updated_at": "2026-08-31T18:00:39",
+      "updated_at": "2026-09-02T20:07:06",
       "weight": 0.5
     },
     {
@@ -1092,7 +1092,7 @@
       "id": "code-sym-kindex-58d630bc994a",
       "title": "ClaudeChannelConfig",
       "type": "concept",
-      "updated_at": "2026-08-31T18:00:39",
+      "updated_at": "2026-09-02T20:07:06",
       "weight": 0.5
     },
     {
@@ -1114,7 +1114,7 @@
       "id": "code-sym-kindex-608ef82e510c",
       "title": "Config",
       "type": "concept",
-      "updated_at": "2026-08-31T18:00:39",
+      "updated_at": "2026-09-02T20:07:06",
       "weight": 0.5
     },
     {
@@ -1125,7 +1125,7 @@
       "id": "code-sym-kindex-62490d9465aa",
       "title": "TelegramChannelConfig",
       "type": "concept",
-      "updated_at": "2026-08-31T18:00:39",
+      "updated_at": "2026-09-02T20:07:06",
       "weight": 0.5
     },
     {
@@ -1147,7 +1147,7 @@
       "id": "code-sym-kindex-6d1dbf76937d",
       "title": "BudgetConfig",
       "type": "concept",
-      "updated_at": "2026-08-31T18:00:39",
+      "updated_at": "2026-09-02T20:07:06",
       "weight": 0.01
     },
     {
@@ -1169,7 +1169,7 @@
       "id": "code-sym-kindex-74266f41225f",
       "title": "SystemChannelConfig",
       "type": "concept",
-      "updated_at": "2026-08-31T18:00:39",
+      "updated_at": "2026-09-02T20:07:06",
       "weight": 0.5
     },
     {
@@ -1224,7 +1224,7 @@
       "id": "code-sym-kindex-7c4b42dbb2fa",
       "title": "LLMConfig",
       "type": "concept",
-      "updated_at": "2026-08-31T18:00:39",
+      "updated_at": "2026-09-02T20:07:06",
       "weight": 0.01
     },
     {
@@ -1235,7 +1235,7 @@
       "id": "code-sym-kindex-7e4d614285e9",
       "title": "SlackChannelConfig",
       "type": "concept",
-      "updated_at": "2026-08-31T18:00:39",
+      "updated_at": "2026-09-02T20:07:06",
       "weight": 0.5
     },
     {
@@ -1246,7 +1246,7 @@
       "id": "code-sym-kindex-89cc5b13c9e0",
       "title": "EmailChannelConfig",
       "type": "concept",
-      "updated_at": "2026-08-31T18:00:39",
+      "updated_at": "2026-09-02T20:07:06",
       "weight": 0.5
     },
     {
@@ -1268,7 +1268,7 @@
       "id": "code-sym-kindex-95b8acd87972",
       "title": "Store",
       "type": "concept",
-      "updated_at": "2026-08-31T18:00:39",
+      "updated_at": "2026-09-02T20:07:06",
       "weight": 0.01
     },
     {
@@ -1279,7 +1279,7 @@
       "id": "code-sym-kindex-979d447616b7",
       "title": "AgentOverrideConfig",
       "type": "concept",
-      "updated_at": "2026-08-31T18:00:39",
+      "updated_at": "2026-09-02T20:07:06",
       "weight": 0.5
     },
     {
@@ -1301,7 +1301,7 @@
       "id": "code-sym-kindex-9f9f9fbe1087",
       "title": "EditPolicyError",
       "type": "concept",
-      "updated_at": "2026-08-31T18:00:39",
+      "updated_at": "2026-09-02T20:07:06",
       "weight": 0.01
     },
     {
@@ -1334,7 +1334,7 @@
       "id": "code-sym-kindex-a8ad139fc733",
       "title": "LinearPolicyConfig",
       "type": "concept",
-      "updated_at": "2026-08-31T18:00:39",
+      "updated_at": "2026-09-02T20:07:06",
       "weight": 0.5
     },
     {
@@ -1367,7 +1367,7 @@
       "id": "code-sym-kindex-b166b6681594",
       "title": "LockHeldError",
       "type": "concept",
-      "updated_at": "2026-08-31T18:00:39",
+      "updated_at": "2026-09-02T20:07:06",
       "weight": 0.01
     },
     {
@@ -1389,7 +1389,7 @@
       "id": "code-sym-kindex-b37057535f7f",
       "title": "StaleReviewError",
       "type": "concept",
-      "updated_at": "2026-08-31T18:45:07",
+      "updated_at": "2026-09-02T20:07:06",
       "weight": 0.01
     },
     {
@@ -1400,7 +1400,7 @@
       "id": "code-sym-kindex-b3b8d9cad562",
       "title": "TraversalResult",
       "type": "concept",
-      "updated_at": "2026-05-24T14:04:22",
+      "updated_at": "2026-09-02T20:07:06",
       "weight": 0.01
     },
     {
@@ -1422,7 +1422,7 @@
       "id": "code-sym-kindex-b42e459fa446",
       "title": "DefaultsConfig",
       "type": "concept",
-      "updated_at": "2026-08-31T18:00:39",
+      "updated_at": "2026-09-02T20:07:06",
       "weight": 0.5
     },
     {
@@ -1455,7 +1455,7 @@
       "id": "code-sym-kindex-b724908147cc",
       "title": "ProfileMismatchError",
       "type": "concept",
-      "updated_at": "2026-08-31T18:00:39",
+      "updated_at": "2026-09-02T20:07:06",
       "weight": 0.01
     },
     {
@@ -1466,7 +1466,7 @@
       "id": "code-sym-kindex-b90676bdf42f",
       "title": "EmbeddingConfig",
       "type": "concept",
-      "updated_at": "2026-08-31T18:00:39",
+      "updated_at": "2026-09-02T20:07:06",
       "weight": 0.5
     },
     {
@@ -1477,7 +1477,7 @@
       "id": "code-sym-kindex-c30edae67b27",
       "title": "CodeIngestConfig",
       "type": "concept",
-      "updated_at": "2026-08-31T18:00:39",
+      "updated_at": "2026-09-02T20:07:06",
       "weight": 0.01
     },
     {
@@ -1488,7 +1488,7 @@
       "id": "code-sym-kindex-c644dbd33873",
       "title": "GitPolicyConfig",
       "type": "concept",
-      "updated_at": "2026-08-31T18:00:39",
+      "updated_at": "2026-09-02T20:07:06",
       "weight": 0.5
     },
     {
@@ -1554,7 +1554,7 @@
       "id": "code-sym-kindex-d1aead4dfe46",
       "title": "TitleCollisionError",
       "type": "concept",
-      "updated_at": "2026-08-31T18:45:07",
+      "updated_at": "2026-09-02T20:07:06",
       "weight": 0.01
     },
     {
@@ -1567,6 +1567,17 @@
       "type": "concept",
       "updated_at": "2026-07-15T23:28:47",
       "weight": 0.01
+    },
+    {
+      "domains": [
+        "code",
+        "python"
+      ],
+      "id": "code-sym-kindex-db305b174dc2",
+      "title": "AdvocateConfig",
+      "type": "concept",
+      "updated_at": "2026-09-02T20:07:06",
+      "weight": 0.5
     },
     {
       "domains": [
@@ -1587,7 +1598,7 @@
       "id": "code-sym-kindex-e0b23690c2bb",
       "title": "CandidateStateError",
       "type": "concept",
-      "updated_at": "2026-08-31T18:45:07",
+      "updated_at": "2026-09-02T20:07:06",
       "weight": 0.01
     },
     {
@@ -1609,7 +1620,7 @@
       "id": "code-sym-kindex-e3fc793d7353",
       "title": "GraphStats",
       "type": "concept",
-      "updated_at": "2026-05-24T14:04:22",
+      "updated_at": "2026-09-02T20:07:06",
       "weight": 0.01
     },
     {
@@ -1620,7 +1631,7 @@
       "id": "code-sym-kindex-e7d77ef2ec54",
       "title": "CaptureConfig",
       "type": "concept",
-      "updated_at": "2026-08-31T18:45:07",
+      "updated_at": "2026-09-02T20:07:06",
       "weight": 0.01
     },
     {
@@ -1642,7 +1653,7 @@
       "id": "code-sym-kindex-f23dff30a8e5",
       "title": "CandidateNotFoundError",
       "type": "concept",
-      "updated_at": "2026-08-31T18:45:07",
+      "updated_at": "2026-09-02T20:07:06",
       "weight": 0.01
     },
     {
@@ -1653,7 +1664,7 @@
       "id": "code-sym-kindex-fe4d5554b184",
       "title": "ChannelsConfig",
       "type": "concept",
-      "updated_at": "2026-08-31T18:00:39",
+      "updated_at": "2026-09-02T20:07:06",
       "weight": 0.5
     }
   ],

--- a/README.md
+++ b/README.md
@@ -305,10 +305,10 @@ kin remind exec --reminder-id <id>
 
 ### Dream — Knowledge Consolidation
 
-Kindex can run fuzzy deduplication, auto-apply pending suggestions, and strengthen edges between nodes that share domains. Like memory consolidation during sleep — replay, strengthen important paths, prune noise.
+Kindex can run fuzzy deduplication, auto-apply high-confidence pending suggestions, and stage bounded domain-link proposals for review. Resolved fuzzy matches are not recreated. The pending domain-review queue is capped per graph (50 by default), proposals are round-robin across domains, and rejected pairs stay rejected. Shared domains are never materialized directly as semantic edges. Like memory consolidation during sleep — replay important paths and prune noise without turning tags into topology.
 
 ```bash
-# See what would happen (no changes)
+# See exact merge and domain-link proposals (no changes)
 kin dream --dry-run
 
 # Run full consolidation
@@ -386,8 +386,14 @@ kin ingest all
 # Session tags — named work context handles
 kin tag start auth-refactor --focus "OAuth2 flow" --remaining "tokens,tests"
 kin tag segment --focus "Token storage" --summary "Flow design done"
-kin tag resume auth-refactor   # admission-controlled context for new session
+kin tag pause auth-refactor --summary "Waiting for review"
+kin tag resume auth-refactor   # reactivate and render admission-controlled context
 kin tag end --summary "All done"
+
+# Completed, unlinked session tags age into the reversible slow archive;
+# active, paused, and artifact-linked sessions stay in the fast store.
+kin archive search auth-refactor
+kin archive restore <session-node-id>
 
 # Reminders — never forget, never nag
 kin remind create "standup" --at "every weekday at 9am" --priority high
@@ -811,8 +817,8 @@ Dream (kin dream):
   Modes:         lightweight (<5s) | full (non-LLM) | deep (claude -p clusters)
   Triggers:      CLI | cron step 11 | throttled Stop-time detach
   Dedup:         difflib.SequenceMatcher, 4-char title bucketing, 0.95 merge / 0.85 suggest
-  Consolidation: suggestion auto-apply, domain edge strengthening, cluster summarisation
-  Safety:        fcntl.flock exclusion, protected types skip, provenance tracking
+  Consolidation: suggestion auto-apply, bounded domain proposals, cluster summarisation
+  Safety:        no tag-derived edges, overlap dedup, fcntl.flock, protected types
 
 Three integration paths:
   MCP plugin --> Claude calls tools natively (search, add, learn, remind, ...)
@@ -862,11 +868,12 @@ Code structure lives in the same graph as your decisions, watches, and constrain
 | `kin supersede <id> <text>` | Replace a node with a new one, preserving history (--reason) |
 | `kin alias <id> [add\|remove\|list]` | Manage AKA/synonyms for a node |
 | `kin register <id> <path>` | Associate a file path with a node |
-| `kin orphans` | Nodes with no connections |
+| `kin orphans` | Semantic nodes with no semantic connections (sessions excluded) |
 | `kin trail <id>` | Temporal history and provenance chain |
 | `kin decay` | Apply weight decay to stale nodes/edges |
 | `kin recent` | Recently active nodes |
 | `kin tag [action]` | Session tags: start, update, segment, pause, end, resume, list, show |
+| `kin archive [action]` | Search, restore, or run the reversible slow-graph archive |
 | `kin candidate [action]` | Quarantined capture review: list, show, accept, reject, prune, erase |
 | `kin verify <node>` | Assert verification and optional RFC 3339 valid interval |
 | `kin invalidate <node>` | Record asserted invalidation actor, code, and exclusive end time |
@@ -916,7 +923,7 @@ gain explicit contextual support.
 |---------|-------------|
 | `kin ingest <source>` | Ingest from: projects, sessions, codex-sessions, files, commits, github, linear, code, all |
 | `kin cron` | One-shot maintenance cycle (for crontab/launchd) |
-| `kin dream` | Knowledge consolidation: dedup, suggestions, edge strengthening (--deep, --detach) |
+| `kin dream` | Knowledge consolidation: dedup and reviewable link proposals (--deep, --detach) |
 | `kin watch` | Watch for new sessions and ingest them (--interval) |
 | `kin analytics` | Archive session analytics and activity heatmap |
 | `kin index` | Write .kin/index.json for git tracking |

--- a/src/kindex/archive.py
+++ b/src/kindex/archive.py
@@ -245,28 +245,47 @@ def find_archivable_nodes(
     """Find nodes eligible for archival to slow graph.
 
     Criteria:
-    - Status is 'archived' (marked by graph hygiene) or 'superseded'
-      (replaced via supersede_node — terminal, weight decays naturally)
-    - Weight below threshold
-    - Not updated in min_age_days
-    - Not a lifecycle type (task, session, etc. handled separately)
+    - Semantic nodes are archived/superseded, low-weight, and old.
+    - Completed session tags are old, unlinked, and have no graph edges.
+    - Active/paused sessions and other lifecycle nodes stay in the fast store.
     """
     now = datetime.datetime.now()
     cutoff = now - datetime.timedelta(days=min_age_days)
     cutoff_iso = cutoff.isoformat(timespec="seconds")
 
     rows = store.conn.execute(
-        """SELECT id, type FROM nodes
-           WHERE status IN ('archived', 'superseded')
-             AND weight <= ?
-             AND updated_at < ?
-           ORDER BY weight ASC, updated_at ASC
-           LIMIT ?""",
-        (weight_threshold, cutoff_iso, limit),
+        """SELECT n.id FROM nodes n
+            WHERE n.updated_at < ?
+              AND (
+                    (
+                        n.status IN ('archived', 'superseded')
+                        AND n.weight <= ?
+                        AND n.type NOT IN ('task', 'session', 'checkpoint',
+                                           'coordination')
+                    )
+                    OR
+                    (
+                        n.type = 'session'
+                        AND json_valid(n.extra)
+                        AND json_extract(n.extra, '$.session_status') = 'completed'
+                        AND COALESCE(
+                            json_array_length(
+                                json_extract(n.extra, '$.linked_nodes')
+                            ),
+                            0
+                        ) = 0
+                        AND NOT EXISTS (
+                            SELECT 1 FROM edges e
+                             WHERE e.from_id = n.id OR e.to_id = n.id
+                        )
+                    )
+              )
+            ORDER BY n.weight ASC, n.updated_at ASC, n.id ASC
+            LIMIT ?""",
+        (cutoff_iso, weight_threshold, limit),
     ).fetchall()
 
-    skip_types = {"task", "session", "checkpoint"}
-    return [r["id"] for r in rows if r["type"] not in skip_types]
+    return [r["id"] for r in rows]
 
 
 def archive_cycle(

--- a/src/kindex/cli.py
+++ b/src/kindex/cli.py
@@ -855,11 +855,11 @@ def cmd_orphans(args):
     orphans = store.orphans()
 
     if orphans:
-        print(f"{len(orphans)} orphan(s):")
+        print(f"{len(orphans)} semantic orphan(s):")
         for n in orphans:
             print(f"  {n['id']}  [{n['type']}] {n['title']}")
     else:
-        print("No orphans. Graph health: good.")
+        print("No semantic orphans. Graph health: good.")
 
     store.close()
 
@@ -978,9 +978,23 @@ def cmd_status(args):
             print(f"Profile: {cfg.active_profile} (via {cfg.profile_source})")
         else:
             print("Profile: (none — legacy single-graph)")
-        print(f"Nodes:     {stats['nodes']}")
-        print(f"Edges:     {stats['edges']}")
+        print(f"Nodes:     {stats['semantic_nodes']} semantic")
+        print(f"Edges:     {stats['edges']} semantic")
         print(f"Orphans:   {stats['orphans']}")
+        stored_nodes = stats["stored_nodes"]
+        semantic_nodes = stats["semantic_nodes"]
+        excluded_nodes = stored_nodes - semantic_nodes
+        ignored = stats.get("stored_edges", 0) - stats.get("edges", 0)
+        if excluded_nodes or ignored:
+            print(
+                f"Stored:    {stored_nodes} nodes, {stats['stored_edges']} edges "
+                f"({excluded_nodes} lifecycle nodes, {ignored} excluded edges)"
+            )
+            print(f"  domain-derived {stats.get('ignored_domain_edges', 0)}")
+            print(f"  session-linked {stats.get('ignored_session_edges', 0)}")
+            other = stats.get("ignored_other_edges", 0)
+            if other:
+                print(f"  unresolved      {other}")
         print(f"\nBy type:")
         for t, c in sorted(stats.get("types", {}).items()):
             print(f"  {t:12s} {c}")
@@ -2412,8 +2426,14 @@ def cmd_suggest(args):
             return
 
         # Resolve concept titles to nodes
-        node_a = store.get_node_by_title(suggestion["concept_a"])
-        node_b = store.get_node_by_title(suggestion["concept_b"])
+        node_a = (
+            store.get_node(suggestion["concept_a"])
+            or store.get_node_by_title(suggestion["concept_a"])
+        )
+        node_b = (
+            store.get_node(suggestion["concept_b"])
+            or store.get_node_by_title(suggestion["concept_b"])
+        )
 
         if node_a and node_b:
             store.add_edge(
@@ -2644,13 +2664,32 @@ def cmd_graph(args):
             print(_dumps(stats, indent=2))
         else:
             print(f"Graph Statistics")
-            print(f"  Nodes:      {stats['nodes']}")
-            print(f"  Edges:      {stats['edges']}")
+            print(f"  Nodes:      {stats['semantic_nodes']} semantic")
+            print(f"  Edges:      {stats['edges']} semantic")
             print(f"  Density:    {stats['density']}")
             print(f"  Components: {stats['components']}")
             print(f"  Avg degree: {stats['avg_degree']}")
             if stats['max_degree_node']:
                 print(f"  Hub:        {stats['max_degree_node']} (degree {stats['max_degree']})")
+            ignored = stats.get("stored_edges", 0) - stats.get("edges", 0)
+            excluded_nodes = stats["stored_nodes"] - stats["semantic_nodes"]
+            if excluded_nodes or ignored:
+                print(
+                    f"  Stored:     {stats['stored_nodes']} nodes, "
+                    f"{stats['stored_edges']} edges ({excluded_nodes} lifecycle "
+                    f"nodes, {ignored} excluded edges)"
+                )
+                print(
+                    "    domain-derived: "
+                    f"{stats.get('ignored_domain_edges', 0)}"
+                )
+                print(
+                    "    session-linked: "
+                    f"{stats.get('ignored_session_edges', 0)}"
+                )
+                other = stats.get("ignored_other_edges", 0)
+                if other:
+                    print(f"    unresolved:     {other}")
 
     elif mode == "centrality":
         method = args.method or "betweenness"
@@ -2857,7 +2896,7 @@ def cmd_sync_links(args):
     updated = 0
 
     for node in nodes:
-        edges = store.edges_from(node["id"])
+        edges = store.edges_from(node["id"], semantic_only=True)
         if not edges:
             continue
 
@@ -3583,7 +3622,7 @@ def cmd_skills(args):
         return
 
     # Find skill edges (demonstrates)
-    edges = store.edges_from(person["id"])
+    edges = store.edges_from(person["id"], semantic_only=True)
     skill_edges = [e for e in edges if e.get("type") == "demonstrates"]
 
     # Also find context_of edges to skill nodes
@@ -3869,8 +3908,27 @@ def cmd_dream(args):
             print(f"  Merged:              {results.get('merged', 0)}")
             print(f"  Suggested:           {results.get('suggested', 0)}")
             print(f"  Suggestions applied: {results.get('suggestions_applied', 0)}")
-            if "edges_strengthened" in results:
-                print(f"  Edges strengthened:  {results['edges_strengthened']}")
+            proposals = results.get("domain_link_proposals", [])
+            if "domain_link_proposals" in results:
+                capped = " (capped)" if results.get(
+                    "domain_link_proposals_capped"
+                ) else ""
+                print(f"  Domain proposals:    {len(proposals)}{capped}")
+                if dry_run:
+                    for proposal in proposals:
+                        print(
+                            f"    [{proposal['domain']}] "
+                            f"{proposal['from_title']} <-> {proposal['to_title']}"
+                        )
+            created = results.get("domain_link_suggestions_created", 0)
+            if created:
+                print(f"  Domain suggestions:  {created} queued for review")
+            if "domain_link_suggestions_pending" in results:
+                print(
+                    "  Domain review queue: "
+                    f"{results['domain_link_suggestions_pending']}/"
+                    f"{results.get('domain_link_proposal_limit', 0)}"
+                )
             if "cluster_summaries" in results:
                 print(f"  Cluster summaries:   {results['cluster_summaries']}")
 
@@ -5562,6 +5620,7 @@ def cmd_tag(args):
                 remaining=remaining,
                 append_remaining=append,
                 remove_remaining=remove,
+                project_path=os.getcwd(),
             )
             print(f"Updated: {tag_name}")
         except ValueError as e:
@@ -5581,7 +5640,13 @@ def cmd_tag(args):
         focus = getattr(args, "focus", None) or "New segment"
         summary = getattr(args, "summary", None) or ""
         try:
-            add_segment(store, tag_name, new_focus=focus, summary=summary)
+            add_segment(
+                store,
+                tag_name,
+                new_focus=focus,
+                summary=summary,
+                project_path=os.getcwd(),
+            )
             print(f"New segment on {tag_name}: {focus}")
         except ValueError as e:
             print(f"Error: {e}", file=sys.stderr)
@@ -5599,7 +5664,9 @@ def cmd_tag(args):
             return
         summary = getattr(args, "summary", None) or ""
         try:
-            pause_tag(store, tag_name, summary=summary)
+            pause_tag(
+                store, tag_name, summary=summary, project_path=os.getcwd()
+            )
             print(f"Paused: {tag_name}")
         except ValueError as e:
             print(f"Error: {e}", file=sys.stderr)
@@ -5617,13 +5684,15 @@ def cmd_tag(args):
             return
         summary = getattr(args, "summary", None) or ""
         try:
-            complete_tag(store, tag_name, summary=summary)
+            complete_tag(
+                store, tag_name, summary=summary, project_path=os.getcwd()
+            )
             print(f"Completed: {tag_name}")
         except ValueError as e:
             print(f"Error: {e}", file=sys.stderr)
 
     elif action == "resume":
-        from .sessions import format_resume_context
+        from .sessions import format_resume_context, resume_tag
 
         if not tag_name:
             print("Usage: kin tag resume <name>", file=sys.stderr)
@@ -5632,13 +5701,18 @@ def cmd_tag(args):
         tokens = getattr(args, "tokens", 1500)
         if tokens is None:
             tokens = 1500
-        block = format_resume_context(
-            store,
-            tag_name,
-            max_tokens=tokens,
-            evaluation_time=operation_now(),
-        )
-        print(block)
+        try:
+            resume_tag(store, tag_name, project_path=os.getcwd())
+            block = format_resume_context(
+                store,
+                tag_name,
+                max_tokens=tokens,
+                evaluation_time=operation_now(),
+                project_path=os.getcwd(),
+            )
+            print(block)
+        except ValueError as e:
+            print(f"Error: {e}", file=sys.stderr)
 
     elif action == "list":
         from .sessions import list_tags
@@ -5665,7 +5739,7 @@ def cmd_tag(args):
             print("Usage: kin tag show <name>", file=sys.stderr)
             store.close()
             return
-        tag = get_tag(store, tag_name)
+        tag = get_tag(store, tag_name, project_path=os.getcwd())
         if not tag:
             print(f"Tag not found: {tag_name}", file=sys.stderr)
             store.close()
@@ -6697,7 +6771,7 @@ def build_parser() -> argparse.ArgumentParser:
     s.set_defaults(func=cmd_recent)
 
     # orphans
-    s = sub.add_parser("orphans", help="Nodes with no edges")
+    s = sub.add_parser("orphans", help="Semantic nodes with no semantic edges")
     _common(s)
     s.set_defaults(func=cmd_orphans)
 

--- a/src/kindex/code_map.py
+++ b/src/kindex/code_map.py
@@ -398,7 +398,7 @@ def export_understand_anything(
     ua_edges = []
     seen_edges: set[tuple[str, str, str]] = set()
     for node in code_nodes:
-        for edge in store.edges_from(node["id"]):
+        for edge in store.edges_from(node["id"], semantic_only=True):
             target = edge.get("to_id")
             if target not in code_ids:
                 continue

--- a/src/kindex/config.py
+++ b/src/kindex/config.py
@@ -608,6 +608,7 @@ class ReminderConfig(BaseModel):
     dream_on_stop_enabled: bool = True  # run throttled knowledge consolidation when Claude exits
     dream_min_interval: int = 3600      # seconds between scheduled/hook dream runs
     dream_max_new_suggestions: int = 100  # cap suggestion writes per dream run
+    dream_max_domain_link_suggestions: int = 50  # pending review cap per graph
     stop_guard_window: int = 7200      # seconds (2h) — block exit if actions due within
     channels: ChannelsConfig = Field(default_factory=ChannelsConfig)
     adaptive_scheduling: bool = True   # dynamically adjust cron interval

--- a/src/kindex/daemon.py
+++ b/src/kindex/daemon.py
@@ -569,7 +569,10 @@ def _graph_hygiene(store: "Store", verbose: bool = False) -> dict:
             if mid == oid:
                 continue
             # Only link to nodes that already have edges (not other orphans)
-            if not store.edges_from(mid) and not store.edges_to(mid):
+            if (
+                not store.edges_from(mid, semantic_only=True)
+                and not store.edges_to(mid, semantic_only=True)
+            ):
                 continue
             # Create a low-weight link
             store.add_edge(

--- a/src/kindex/dream.py
+++ b/src/kindex/dream.py
@@ -3,7 +3,7 @@
 Performs memory consolidation on the knowledge graph:
 - Fuzzy deduplication (title similarity + content overlap)
 - Suggestion auto-application
-- Domain-based edge strengthening
+- Bounded, reviewable domain-link proposals
 
 Three invocation modes:
 - lightweight: dedup + suggestions only, <5s target
@@ -45,6 +45,8 @@ PROTECTED_TYPES = (frozenset(EDIT_POLICY["additive"])
 DEFAULT_MERGE_THRESHOLD = 0.95
 DEFAULT_SUGGEST_THRESHOLD = 0.85
 DEFAULT_MAX_NEW_SUGGESTIONS = 100
+DEFAULT_MAX_DOMAIN_LINK_SUGGESTIONS = 50
+DOMAIN_SUGGESTION_SOURCE = "dream-cycle-domain"
 
 # Runaway-merge guards.
 #
@@ -292,7 +294,7 @@ def merge_nodes(store: Store, source_id: str, target_id: str) -> bool:
         return False
 
     # Move edges from source to target
-    for edge in store.edges_from(source_id):
+    for edge in store.edges_from(source_id, semantic_only=True):
         if edge["to_id"] != target_id:
             store.add_edge(
                 target_id, edge["to_id"],
@@ -300,7 +302,7 @@ def merge_nodes(store: Store, source_id: str, target_id: str) -> bool:
                 weight=edge.get("weight", 0.3),
                 provenance="dream-cycle merge",
             )
-    for edge in store.edges_to(source_id):
+    for edge in store.edges_to(source_id, semantic_only=True):
         if edge["from_id"] != target_id:
             store.add_edge(
                 edge["from_id"], target_id,
@@ -339,6 +341,11 @@ def auto_apply_suggestions(store: Store) -> int:
     applied = 0
 
     for s in suggestions:
+        # Domain co-membership is a weak, derived signal. Full Dream stages
+        # those pairs for review; a later lightweight run must not turn them
+        # back into automatic edges.
+        if s.get("source") == DOMAIN_SUGGESTION_SOURCE:
+            continue
         concept_a = s.get("concept_a", "")
         concept_b = s.get("concept_b", "")
 
@@ -359,8 +366,14 @@ def auto_apply_suggestions(store: Store) -> int:
             continue
 
         # Check edge doesn't already exist
-        existing_out = {e["to_id"] for e in store.edges_from(node_a["id"])}
-        existing_in = {e["from_id"] for e in store.edges_to(node_a["id"])}
+        existing_out = {
+            e["to_id"]
+            for e in store.edges_from(node_a["id"], semantic_only=True)
+        }
+        existing_in = {
+            e["from_id"]
+            for e in store.edges_to(node_a["id"], semantic_only=True)
+        }
         if node_b["id"] in existing_out or node_b["id"] in existing_in:
             store.update_suggestion(s["id"], "accepted")
             applied += 1
@@ -378,18 +391,28 @@ def auto_apply_suggestions(store: Store) -> int:
     return applied
 
 
-def strengthen_domain_edges(
+def propose_domain_links(
     store: Store,
     *,
-    dry_run: bool = False,
-    verbose: bool = False,
-) -> int:
-    """Find active nodes sharing domains but lacking edges; create weak links."""
+    limit: int = DEFAULT_MAX_DOMAIN_LINK_SUGGESTIONS,
+) -> tuple[list[dict], bool]:
+    """Return bounded, sparse domain-link proposals without mutating topology.
+
+    Each domain contributes a star around its highest-weight member instead of
+    all pairwise combinations. The returned boolean says whether another valid
+    proposal existed beyond ``limit``.
+    """
     import json
 
-    nodes = store.all_nodes(status="active", limit=2000)
-    # Build domain -> node_ids index
-    domain_index: dict[str, list[dict]] = {}
+    limit = max(0, int(limit))
+    # Use an identity-ordered bounded population. Relevance weights decay, so
+    # taking the top weighted rows would churn both representatives and
+    # candidate membership even when graph content had not changed.
+    rows = store.conn.execute(
+        "SELECT * FROM nodes WHERE status = 'active' ORDER BY id ASC LIMIT 2000"
+    ).fetchall()
+    nodes = [store._row_to_dict(row) for row in rows]
+    domain_index: dict[str, dict[str, dict]] = {}
     for n in nodes:
         if n.get("type", "concept") in PROTECTED_TYPES:
             continue
@@ -400,44 +423,69 @@ def strengthen_domain_edges(
             except (json.JSONDecodeError, TypeError):
                 domains = []
         for d in domains:
-            domain_index.setdefault(d, []).append(n)
+            if isinstance(d, str) and d:
+                domain_index.setdefault(d, {})[n["id"]] = n
 
-    created = 0
+    proposals: list[dict] = []
     seen_pairs: set[tuple[str, str]] = set()
+    neighbor_cache: dict[str, set[str]] = {}
 
-    for domain, members in domain_index.items():
-        if len(members) < 2 or len(members) > 50:
+    def semantic_neighbors(node_id: str) -> set[str]:
+        if node_id not in neighbor_cache:
+            outgoing = {
+                edge["to_id"]
+                for edge in store.edges_from(node_id, semantic_only=True)
+            }
+            incoming = {
+                edge["from_id"]
+                for edge in store.edges_to(node_id, semantic_only=True)
+            }
+            neighbor_cache[node_id] = outgoing | incoming
+        return neighbor_cache[node_id]
+
+    ranked_domains: list[tuple[str, list[dict]]] = []
+    for domain, members_by_id in sorted(domain_index.items()):
+        if len(members_by_id) < 2:
             continue
-        for i, a in enumerate(members):
-            for b in members[i + 1:]:
-                pair = tuple(sorted([a["id"], b["id"]]))
-                if pair in seen_pairs:
-                    continue
-                seen_pairs.add(pair)
+        # IDs are the only immutable node identity. Weight decays and titles
+        # can be edited, so either would make a rejected star reappear around
+        # a different representative on a later Dream cycle.
+        members = sorted(members_by_id.values(), key=lambda node: node["id"])
+        ranked_domains.append((domain, members))
+    # Round-robin across domains so one broad tag cannot consume the entire
+    # graph-wide review budget before narrower domains receive one proposal.
+    domain_round = [(domain, members, 1) for domain, members in ranked_domains]
+    while domain_round:
+        next_round: list[tuple[str, list[dict], int]] = []
+        for domain, members, spoke_index in domain_round:
+            if spoke_index + 1 < len(members):
+                next_round.append((domain, members, spoke_index + 1))
+            representative = members[0]
+            member = members[spoke_index]
+            pair = tuple(sorted((representative["id"], member["id"])))
+            if pair in seen_pairs:
+                continue
+            seen_pairs.add(pair)
+            if member["id"] in semantic_neighbors(representative["id"]):
+                continue
+            if store.suggestion_exists(
+                representative["id"], member["id"], status=None
+            ):
+                continue
+            if len(proposals) >= limit:
+                return proposals, True
+            proposals.append(
+                {
+                    "from_id": representative["id"],
+                    "from_title": representative.get("title", ""),
+                    "to_id": member["id"],
+                    "to_title": member.get("title", ""),
+                    "domain": domain,
+                }
+            )
+        domain_round = next_round
 
-                # Check if edge already exists
-                existing = {e["to_id"] for e in store.edges_from(a["id"])}
-                if b["id"] in existing:
-                    continue
-                existing_rev = {e["from_id"] for e in store.edges_to(a["id"])}
-                if b["id"] in existing_rev:
-                    continue
-
-                if dry_run:
-                    created += 1
-                    continue
-
-                store.add_edge(
-                    a["id"], b["id"],
-                    edge_type="relates_to",
-                    weight=0.15,
-                    provenance="dream-cycle domain co-membership",
-                )
-                created += 1
-                if verbose and created <= 10:
-                    print(f"  Domain link: {a['title']} <-> {b['title']} ({domain})")
-
-    return created
+    return proposals, False
 
 
 # ── Dream cycles ─────────────────────────────────────────────────────
@@ -516,7 +564,7 @@ def dream_lightweight(
         if suggested >= max_new_suggestions:
             suggestion_capped = True
             break
-        if store.suggestion_exists(a_id, b_id):
+        if store.suggestion_exists(a_id, b_id, status=None):
             existing_suggestions += 1
             continue
         store.add_suggestion(
@@ -550,15 +598,45 @@ def dream_full(
     verbose: bool = False,
     dry_run: bool = False,
 ) -> dict:
-    """Full dream cycle: lightweight + edge strengthening.
+    """Full dream cycle: lightweight work plus domain-link suggestions.
 
     No LLM calls.
     """
     results = dream_lightweight(config, store, verbose=verbose, dry_run=dry_run)
 
-    # Strengthen edges between nodes that share domains
-    strengthened = strengthen_domain_edges(store, dry_run=dry_run, verbose=verbose)
-    results["edges_strengthened"] = strengthened
+    limit = max(
+        0,
+        int(
+            getattr(
+                config.reminders,
+                "dream_max_domain_link_suggestions",
+                DEFAULT_MAX_DOMAIN_LINK_SUGGESTIONS,
+            )
+            or 0
+        ),
+    )
+    pending = store.conn.execute(
+        """SELECT COUNT(*) FROM suggestions
+             WHERE status = 'pending' AND kind = 'bridge' AND source = ?""",
+        (DOMAIN_SUGGESTION_SOURCE,),
+    ).fetchone()[0]
+    available = max(0, limit - pending)
+    proposals, capped = propose_domain_links(store, limit=available)
+    created = 0
+    if not dry_run:
+        for proposal in proposals:
+            store.add_suggestion(
+                proposal["from_id"],
+                proposal["to_id"],
+                reason=f"Shared domain: {proposal['domain']}",
+                source=DOMAIN_SUGGESTION_SOURCE,
+            )
+            created += 1
+    results["domain_link_proposals"] = proposals
+    results["domain_link_proposal_limit"] = limit
+    results["domain_link_proposals_capped"] = capped
+    results["domain_link_suggestions_created"] = created
+    results["domain_link_suggestions_pending"] = pending + created
 
     return results
 

--- a/src/kindex/dream_deep.py
+++ b/src/kindex/dream_deep.py
@@ -9,6 +9,7 @@ Only invoked when user explicitly passes --deep flag.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 import subprocess
@@ -21,6 +22,9 @@ if TYPE_CHECKING:
 from .dream import PROTECTED_TYPES, dream_full
 
 logger = logging.getLogger(__name__)
+
+DEFAULT_CLUSTER_OVERLAP_THRESHOLD = 0.6
+CLUSTER_SUMMARY_SOURCE = "dream-deep-cluster-summary"
 
 
 def dream_deep(
@@ -40,8 +44,33 @@ def dream_deep(
     # Find dense clusters for summarisation
     clusters = _find_clusters(store, min_size=4, max_hops=2)
     summaries_created = 0
+    existing_signatures: set[str] = set()
+    existing_member_sets: list[set[str]] = []
+    for row in store.conn.execute(
+        """SELECT extra FROM nodes
+             WHERE status = 'active' AND prov_source = ? AND json_valid(extra)""",
+        (CLUSTER_SUMMARY_SOURCE,),
+    ).fetchall():
+        extra = json.loads(row["extra"] or "{}")
+        signature = extra.get("cluster_signature")
+        if isinstance(signature, str) and signature:
+            existing_signatures.add(signature)
+        members = extra.get("cluster_members")
+        if isinstance(members, list):
+            member_ids = {member for member in members if isinstance(member, str)}
+            if member_ids:
+                existing_member_sets.append(member_ids)
 
-    for cluster in clusters[:5]:  # cap at 5 clusters per dream
+    for cluster in clusters:
+        if summaries_created >= 5:
+            break
+        signature = _cluster_signature(cluster)
+        member_ids = {node["id"] for node in cluster}
+        if signature in existing_signatures or any(
+            _clusters_overlap(member_ids, existing)
+            for existing in existing_member_sets
+        ):
+            continue
         if dry_run:
             logger.info("Would summarise cluster: %s", [n["title"] for n in cluster])
             summaries_created += 1
@@ -61,8 +90,12 @@ def dream_deep(
             content=summary["content"],
             node_type="concept",
             prov_activity="dream-cycle",
-            prov_source="dream-deep-cluster-summary",
+            prov_source=CLUSTER_SUMMARY_SOURCE,
             weight=max(n.get("weight", 0.5) for n in cluster),
+            extra={
+                "cluster_signature": signature,
+                "cluster_members": sorted(node["id"] for node in cluster),
+            },
         )
         for member in cluster:
             store.add_edge(
@@ -72,6 +105,8 @@ def dream_deep(
                 provenance="dream-cycle cluster summary",
             )
         summaries_created += 1
+        existing_signatures.add(signature)
+        existing_member_sets.append(member_ids)
         if verbose:
             print(f"  Cluster summary: {summary['title']} ({len(cluster)} members)")
 
@@ -84,14 +119,19 @@ def _find_clusters(
 ) -> list[list[dict]]:
     """Find dense clusters of related nodes sharing domains."""
     nodes = store.all_nodes(status="active", limit=2000)
-    nodes = [n for n in nodes if n.get("type", "concept") not in PROTECTED_TYPES]
+    nodes = [
+        node
+        for node in nodes
+        if node.get("type", "concept") not in PROTECTED_TYPES
+        and node.get("prov_source") != CLUSTER_SUMMARY_SOURCE
+    ]
 
     # Build adjacency from edges
     adj: dict[str, set[str]] = {}
     for n in nodes:
         nid = n["id"]
         adj.setdefault(nid, set())
-        for e in store.edges_from(nid):
+        for e in store.edges_from(nid, semantic_only=True):
             adj[nid].add(e["to_id"])
             adj.setdefault(e["to_id"], set()).add(nid)
 
@@ -141,10 +181,62 @@ def _find_clusters(
             continue
         visited_clusters.add(key)
 
-        clusters.append([node_map[nid] for nid in cluster_ids])
+        clusters.append([node_map[nid] for nid in sorted(cluster_ids)])
 
-    clusters.sort(key=len, reverse=True)
-    return clusters[:10]
+    return _dedupe_overlapping_clusters(clusters)[:10]
+
+
+def _dedupe_overlapping_clusters(
+    clusters: list[list[dict]],
+    threshold: float = DEFAULT_CLUSTER_OVERLAP_THRESHOLD,
+) -> list[list[dict]]:
+    """Keep deterministic clusters while suppressing subsets and high overlap."""
+    ordered = sorted(
+        (
+            sorted(cluster, key=lambda node: node["id"])
+            for cluster in clusters
+        ),
+        key=lambda cluster: (
+            -len(cluster),
+            tuple(node["id"] for node in cluster),
+        ),
+    )
+    kept: list[list[dict]] = []
+    kept_ids: list[set[str]] = []
+    for cluster in ordered:
+        ids = {node["id"] for node in cluster}
+        if not ids:
+            continue
+        overlaps = False
+        for existing in kept_ids:
+            if _clusters_overlap(ids, existing, threshold):
+                overlaps = True
+                break
+        if not overlaps:
+            kept.append(cluster)
+            kept_ids.append(ids)
+    return kept
+
+
+def _clusters_overlap(
+    left: set[str],
+    right: set[str],
+    threshold: float = DEFAULT_CLUSTER_OVERLAP_THRESHOLD,
+) -> bool:
+    """Return whether two non-empty member sets describe the same cluster."""
+    if not left or not right:
+        return False
+    shared = len(left & right)
+    return (
+        shared == min(len(left), len(right))
+        or shared / len(left | right) >= threshold
+    )
+
+
+def _cluster_signature(cluster: list[dict]) -> str:
+    """Return a stable identity for an exact set of cluster members."""
+    member_ids = "\n".join(sorted(node["id"] for node in cluster))
+    return hashlib.sha256(member_ids.encode("utf-8")).hexdigest()
 
 
 def _parse_domains(node: dict) -> set[str]:

--- a/src/kindex/graph.py
+++ b/src/kindex/graph.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 
 import networkx as nx
 
+from .schema import SEMANTIC_GRAPH_EXCLUDED_NODE_TYPES
 from .vault import Vault
 
 
@@ -192,13 +193,16 @@ def build_nx_from_store(store, limit: int = _NX_BUILD_LIMIT) -> nx.DiGraph:
     """
     G = nx.DiGraph()
 
-    for node in store.all_nodes(limit=limit):
+    for node in store.all_nodes(
+        exclude_types=SEMANTIC_GRAPH_EXCLUDED_NODE_TYPES,
+        limit=limit,
+    ):
         G.add_node(node["id"], title=node["title"], type=node["type"],
                    weight=node.get("weight", 0.5),
                    domains=node.get("domains", []))
 
     for nid in list(G.nodes()):
-        for edge in store.edges_from(nid):
+        for edge in store.edges_from(nid, semantic_only=True):
             if edge["to_id"] in G:
                 G.add_edge(nid, edge["to_id"],
                            weight=edge["weight"],
@@ -215,23 +219,40 @@ def store_stats(store) -> dict:
     Density, components, and degree stats come from the networkx graph
     (may be approximate if the graph exceeds the build limit).
     """
-    # Accurate counts from SQL
-    sql_nodes = store.conn.execute("SELECT COUNT(*) FROM nodes").fetchone()[0]
-    sql_edges = store.conn.execute("SELECT COUNT(*) FROM edges").fetchone()[0]
+    placeholders = ",".join("?" for _ in SEMANTIC_GRAPH_EXCLUDED_NODE_TYPES)
+    semantic_nodes = store.conn.execute(
+        f"SELECT COUNT(*) FROM nodes WHERE type NOT IN ({placeholders})",
+        SEMANTIC_GRAPH_EXCLUDED_NODE_TYPES,
+    ).fetchone()[0]
+    stored_nodes = store.conn.execute("SELECT COUNT(*) FROM nodes").fetchone()[0]
+    edge_counts = store.graph_edge_counts()
 
     G = build_nx_from_store(store)
-    truncated = G.number_of_nodes() < sql_nodes
+    truncated = G.number_of_nodes() < semantic_nodes
 
     if not G:
-        return {"nodes": sql_nodes, "edges": sql_edges, "density": 0,
+        return {"nodes": semantic_nodes, "semantic_nodes": semantic_nodes,
+                "edges": edge_counts["semantic"],
+                "stored_nodes": stored_nodes,
+                "stored_edges": edge_counts["stored"],
+                "ignored_domain_edges": edge_counts["domain"],
+                "ignored_session_edges": edge_counts["session"],
+                "ignored_other_edges": edge_counts["other"],
+                "density": 0,
                 "components": 0, "avg_degree": 0, "max_degree_node": "",
-                "max_degree": 0, "truncated": False}
+                "max_degree": 0, "truncated": truncated}
 
     degrees = dict(G.degree())
     mx = max(degrees, key=degrees.get) if degrees else ""
     return {
-        "nodes": sql_nodes,
-        "edges": sql_edges,
+        "nodes": semantic_nodes,
+        "semantic_nodes": semantic_nodes,
+        "edges": edge_counts["semantic"],
+        "stored_nodes": stored_nodes,
+        "stored_edges": edge_counts["stored"],
+        "ignored_domain_edges": edge_counts["domain"],
+        "ignored_session_edges": edge_counts["session"],
+        "ignored_other_edges": edge_counts["other"],
         "density": round(nx.density(G), 4),
         "components": nx.number_weakly_connected_components(G),
         "avg_degree": round(sum(degrees.values()) / len(degrees), 2) if degrees else 0,

--- a/src/kindex/hooks.py
+++ b/src/kindex/hooks.py
@@ -576,13 +576,18 @@ def capture_session_end(
             from .sessions import get_active_tag, link_node_to_tag
             import os
 
-            active_tag = get_active_tag(store, project_path=os.getcwd())
+            project_path = os.getcwd()
+            active_tag = get_active_tag(store, project_path=project_path)
             if active_tag:
                 tag_name = (active_tag.get("extra") or {}).get("tag", active_tag["title"])
                 for nid in created_ids:
-                    link_node_to_tag(store, tag_name, nid)
-        except Exception:
-            pass  # Don't break session end capture
+                    link_node_to_tag(
+                        store, tag_name, nid, project_path=project_path
+                    )
+        except Exception as exc:
+            # Hooks stay non-blocking, but a failed lifecycle link must remain
+            # visible in the degraded-event ledger.
+            _record_section_degraded("session-end-tag-link", exc, config)
 
     return count
 

--- a/src/kindex/ingest.py
+++ b/src/kindex/ingest.py
@@ -935,7 +935,7 @@ def detect_expertise(store: "Store", person_node_id: str) -> dict[str, int]:
     domain_counts: Counter[str] = Counter()
 
     # 1. Tally domains from directly connected nodes
-    edges = store.edges_from(person_node_id)
+    edges = store.edges_from(person_node_id, semantic_only=True)
     for edge in edges:
         target_id = edge.get("to_id")
         if not target_id:

--- a/src/kindex/mcp_server.py
+++ b/src/kindex/mcp_server.py
@@ -310,7 +310,7 @@ def _node_detail(store, node: dict) -> str:
     if node.get("content"):
         lines.append(f"\n{node['content']}")
 
-    edges = store.edges_from(node["id"])
+    edges = store.edges_from(node["id"], semantic_only=True)
     if edges:
         lines.append(f"\n## Connections ({len(edges)})")
         for e in edges[:20]:
@@ -1007,10 +1007,23 @@ def status() -> str:
 
     lines = [
         "# Kindex Status\n",
-        f"Nodes: {stats.get('nodes', 0)}",
-        f"Edges: {stats.get('edges', 0)}",
-        f"Orphans: {stats.get('orphans', 0)}",
+        f"Nodes: {stats['semantic_nodes']} semantic",
+        f"Edges: {stats['edges']} semantic",
+        f"Orphans: {stats['orphans']} semantic",
     ]
+    stored_nodes = stats["stored_nodes"]
+    stored_edges = stats["stored_edges"]
+    excluded_nodes = stored_nodes - stats["semantic_nodes"]
+    excluded_edges = stored_edges - stats["edges"]
+    if excluded_nodes or excluded_edges:
+        lines.extend([
+            f"Stored nodes: {stored_nodes} ({excluded_nodes} lifecycle)",
+            f"Stored edges: {stored_edges} ({excluded_edges} excluded)",
+            f"  Domain-derived: {stats.get('ignored_domain_edges', 0)}",
+            f"  Session-linked: {stats.get('ignored_session_edges', 0)}",
+        ])
+        if stats.get("ignored_other_edges", 0):
+            lines.append(f"  Unresolved: {stats['ignored_other_edges']}")
 
     type_counts = stats.get("types", {})
     if type_counts:
@@ -1232,12 +1245,25 @@ def graph_stats() -> str:
 
     lines = [
         "# Graph Analytics\n",
-        f"Nodes: {stats.get('nodes', 0)}",
-        f"Edges: {stats.get('edges', 0)}",
+        f"Nodes: {stats['semantic_nodes']} semantic",
+        f"Edges: {stats['edges']} semantic",
         f"Density: {stats.get('density', 0):.4f}",
         f"Components: {stats.get('components', 0)}",
         f"Avg Degree: {stats.get('avg_degree', 0):.1f}",
     ]
+    stored_nodes = stats["stored_nodes"]
+    stored_edges = stats["stored_edges"]
+    excluded_nodes = stored_nodes - stats["semantic_nodes"]
+    excluded_edges = stored_edges - stats["edges"]
+    if excluded_nodes or excluded_edges:
+        lines.extend([
+            f"Stored nodes: {stored_nodes} ({excluded_nodes} lifecycle)",
+            f"Stored edges: {stored_edges} ({excluded_edges} excluded)",
+            f"  Domain-derived: {stats.get('ignored_domain_edges', 0)}",
+            f"  Session-linked: {stats.get('ignored_session_edges', 0)}",
+        ])
+        if stats.get("ignored_other_edges", 0):
+            lines.append(f"  Unresolved: {stats['ignored_other_edges']}")
     if stats.get("truncated"):
         lines.append(f"\n*Note: graph analysis used a subset of nodes. "
                      f"Density/centrality/community stats are approximate.*")
@@ -1279,7 +1305,8 @@ def graph_heal() -> str:
 
     # Stats overview
     stats = store_stats(store)
-    lines.append(f"Nodes: {stats.get('nodes', 0)}, Edges: {stats.get('edges', 0)}, "
+    lines.append(f"Semantic nodes: {stats['semantic_nodes']}, "
+                 f"semantic edges: {stats['edges']}, "
                  f"Components: {stats.get('components', 0)}, "
                  f"Density: {stats.get('density', 0):.4f}\n")
 
@@ -1454,14 +1481,14 @@ def graph_merge(source_id: str, target_id: str, keep: str = "target",
 
     # Move edges from source to target
     moved = 0
-    for edge in store.edges_from(source_id):
+    for edge in store.edges_from(source_id, semantic_only=True):
         if edge["to_id"] != target_id:
             store.add_edge(target_id, edge["to_id"],
                            edge_type=edge.get("type", "relates_to"),
                            weight=edge.get("weight", 0.3),
                            provenance=f"merged from {source['title']}")
             moved += 1
-    for edge in store.edges_to(source_id):
+    for edge in store.edges_to(source_id, semantic_only=True):
         if edge["from_id"] != target_id:
             store.add_edge(edge["from_id"], target_id,
                            edge_type=edge.get("type", "relates_to"),
@@ -1510,7 +1537,7 @@ def dream(
     """Run knowledge consolidation (dream cycle).
 
     Performs memory consolidation: fuzzy deduplication, suggestion
-    auto-application, and domain-based edge strengthening. Like sleep
+    auto-application, and bounded domain-link proposals for review. Like sleep
     consolidating memory — replay, strengthen, prune.
 
     Args:
@@ -1530,8 +1557,25 @@ def dream(
     lines.append(f"  Merged: {results.get('merged', 0)}")
     lines.append(f"  Suggested: {results.get('suggested', 0)}")
     lines.append(f"  Suggestions applied: {results.get('suggestions_applied', 0)}")
-    if "edges_strengthened" in results:
-        lines.append(f"  Edges strengthened: {results['edges_strengthened']}")
+    proposals = results.get("domain_link_proposals", [])
+    if "domain_link_proposals" in results:
+        capped = " (capped)" if results.get("domain_link_proposals_capped") else ""
+        lines.append(f"  Domain proposals: {len(proposals)}{capped}")
+        if dry_run:
+            for proposal in proposals:
+                lines.append(
+                    f"    [{proposal['domain']}] {proposal['from_title']} "
+                    f"<-> {proposal['to_title']}"
+                )
+    created = results.get("domain_link_suggestions_created", 0)
+    if created:
+        lines.append(f"  Domain suggestions: {created} queued for review")
+    if "domain_link_suggestions_pending" in results:
+        lines.append(
+            "  Domain review queue: "
+            f"{results['domain_link_suggestions_pending']}/"
+            f"{results.get('domain_link_proposal_limit', 0)}"
+        )
     if "cluster_summaries" in results:
         lines.append(f"  Cluster summaries: {results['cluster_summaries']}")
     return "\n".join(lines)
@@ -1716,7 +1760,8 @@ def orient() -> str:
 
     lines = [
         "# Kindex Orientation\n",
-        f"Graph: {stats.get('nodes', 0)} nodes, {stats.get('edges', 0)} edges, "
+        f"Graph: {stats['semantic_nodes']} semantic nodes, "
+        f"{stats['edges']} semantic edges, "
         f"{stats.get('components', 0)} component(s)\n",
     ]
 
@@ -1766,7 +1811,14 @@ def tag_start(name: str, description: str = "", focus: str = "",
         return f"Error: {e}"
 
 
-def _reinforce_on_end(store, config, tag_name: str, summary: str) -> str:
+def _reinforce_on_end(
+    store,
+    config,
+    tag_name: str,
+    summary: str,
+    *,
+    project_path: str | None = None,
+) -> str:
     """Private helper (NOT an MCP tool — it takes store/config directly).
 
     Silently queue this session for later reinforcement grading (no LLM, no
@@ -1786,7 +1838,7 @@ def _reinforce_on_end(store, config, tag_name: str, summary: str) -> str:
             return ""
 
         parts = [summary] if summary else []
-        tag = get_tag(store, tag_name)
+        tag = get_tag(store, tag_name, project_path=project_path)
         if tag:
             parts.append(tag.get("content", "") or "")
             for seg in (tag.get("extra") or {}).get("segments", []) or []:
@@ -1823,6 +1875,7 @@ def tag_update(name: str = "", focus: str = "", description: str = "",
     from .sessions import (update_tag, add_segment, pause_tag,
                            complete_tag, get_active_tag, get_tag)
     import os
+    project_path = os.getcwd()
 
     if not name:
         active = get_active_tag(store, project_path=os.getcwd())
@@ -1839,17 +1892,30 @@ def tag_update(name: str = "", focus: str = "", description: str = "",
                 remaining=[r.strip() for r in remaining.split(",") if r.strip()] if remaining else None,
                 append_remaining=[r.strip() for r in add_remaining.split(",") if r.strip()] if add_remaining else None,
                 remove_remaining=[r.strip() for r in done.split(",") if r.strip()] if done else None,
+                project_path=project_path,
             )
             return f"Updated tag: {name}"
         elif action == "segment":
-            add_segment(store, name, new_focus=focus or "New segment", summary=summary)
+            add_segment(
+                store,
+                name,
+                new_focus=focus or "New segment",
+                summary=summary,
+                project_path=project_path,
+            )
             return f"New segment on {name}: {focus}"
         elif action == "pause":
-            pause_tag(store, name, summary=summary)
+            pause_tag(store, name, summary=summary, project_path=project_path)
             return f"Paused: {name}"
         elif action == "end":
-            complete_tag(store, name, summary=summary)
-            note = _reinforce_on_end(store, config, name, summary)
+            complete_tag(store, name, summary=summary, project_path=project_path)
+            note = _reinforce_on_end(
+                store,
+                config,
+                name,
+                summary,
+                project_path=project_path,
+            )
             return f"Completed: {name}{note}"
         return f"Unknown action: {action}"
     except ValueError as e:
@@ -1867,11 +1933,18 @@ def tag_resume(name: str = "", tokens: int = 1500) -> str:
             direct library caller to supply that provider's exact counter.
     """
     store, _ = _get_store()
-    from .sessions import format_resume_context, list_tags
+    from .sessions import format_resume_context, list_tags, resume_tag
+    import os
+
+    project_path = os.getcwd()
 
     if not name:
-        tags = list_tags(store, status="active", limit=5)
-        tags += list_tags(store, status="paused", limit=5)
+        tags = list_tags(
+            store, status="active", project_path=project_path, limit=5
+        )
+        tags += list_tags(
+            store, status="paused", project_path=project_path, limit=5
+        )
         if not tags:
             return "No active or paused session tags."
         lines = ["Available session tags:\n"]
@@ -1882,12 +1955,17 @@ def tag_resume(name: str = "", tokens: int = 1500) -> str:
                          f"{extra.get('current_focus', '')[:60]}")
         return "\n".join(lines)
 
-    return format_resume_context(
-        store,
-        name,
-        max_tokens=tokens,
-        evaluation_time=operation_now(),
-    )
+    try:
+        resume_tag(store, name, project_path=project_path)
+        return format_resume_context(
+            store,
+            name,
+            max_tokens=tokens,
+            evaluation_time=operation_now(),
+            project_path=project_path,
+        )
+    except ValueError as e:
+        return f"Error: {e}"
 
 
 # ── Tasks ─────────────────────────────────────────────────────────────

--- a/src/kindex/retrieve.py
+++ b/src/kindex/retrieve.py
@@ -563,7 +563,9 @@ def hybrid_search(
             seen.add(node["id"])
             node["confidence"] = round(score, 4)
             node["rrf_score"] = round(score, 6)  # backward compat
-            node["edges_out"] = store.edges_from(node["id"])[:5]
+            node["edges_out"] = store.edges_from(
+                node["id"], semantic_only=True
+            )[:5]
             results.append(node)
         except Exception:
             continue  # one malformed candidate never zeroes retrieval
@@ -1258,7 +1260,7 @@ def predict_tier2(
     predicted: dict[str, dict] = {}
 
     for hit in search_results[:3]:
-        for edge in store.edges_from(hit["id"])[:5]:
+        for edge in store.edges_from(hit["id"], semantic_only=True)[:5]:
             tid = edge["to_id"]
             if tid not in hit_ids and tid not in predicted:
                 node = store.get_node(tid)

--- a/src/kindex/schema.py
+++ b/src/kindex/schema.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-SCHEMA_VERSION = 11
+SCHEMA_VERSION = 12
 
 # Audience scopes for tenancy model
 AUDIENCES = ("private", "team", "org", "public")
@@ -22,6 +22,15 @@ OPERATIONAL_TYPES = (
 )
 
 ALL_NODE_TYPES = NODE_TYPES + OPERATIONAL_TYPES
+
+# Session nodes record agent-run lifecycle. They remain queryable history, but
+# they are not knowledge-topology vertices and do not need semantic edges.
+SEMANTIC_GRAPH_EXCLUDED_NODE_TYPES = ("session",)
+
+# v0.35 and earlier materialized shared node domains as pairwise edges. Those
+# edges are derived from attributes already stored on each endpoint and must not
+# participate in semantic traversal or graph-health metrics.
+LEGACY_DREAM_DOMAIN_EDGE_PROVENANCE = "dream-cycle domain co-membership"
 
 # Edge types — bidirectional by convention
 EDGE_TYPES = (
@@ -154,6 +163,14 @@ CREATE INDEX IF NOT EXISTS idx_nodes_status ON nodes(status);
 CREATE INDEX IF NOT EXISTS idx_nodes_updated ON nodes(updated_at);
 CREATE INDEX IF NOT EXISTS idx_nodes_weight ON nodes(weight DESC);
 CREATE INDEX IF NOT EXISTS idx_nodes_audience ON nodes(audience);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_session_active_tag_project
+    ON nodes (
+        json_extract(extra, '$.tag'),
+        COALESCE(json_extract(extra, '$.project_path'), '')
+    )
+    WHERE type = 'session'
+      AND json_valid(extra)
+      AND json_extract(extra, '$.session_status') = 'active';
 
 -- Activity log for audit trail
 CREATE TABLE IF NOT EXISTS activity_log (
@@ -186,6 +203,8 @@ CREATE INDEX IF NOT EXISTS idx_suggestions_status_created
     ON suggestions(status, created_at DESC);
 CREATE INDEX IF NOT EXISTS idx_suggestions_status_pair
     ON suggestions(status, concept_a, concept_b);
+CREATE INDEX IF NOT EXISTS idx_suggestions_pair
+    ON suggestions(concept_a, concept_b);
 
 -- Automatic extraction is staged here for explicit review. Candidate rows are
 -- deliberately separate from nodes/edges/FTS so no query can accidentally

--- a/src/kindex/sessions.py
+++ b/src/kindex/sessions.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import datetime
 import re
+import sqlite3
 from typing import TYPE_CHECKING, Callable
 
 if TYPE_CHECKING:
@@ -27,13 +28,20 @@ def _normalize_tag(name: str) -> str:
     return name.strip("-")
 
 
-def get_tag(store: Store, name: str) -> dict | None:
+def get_tag(
+    store: Store,
+    name: str,
+    *,
+    project_path: str | None = None,
+) -> dict | None:
     """Look up a session tag by name. Returns the node dict or None."""
-    tag = store.get_session_tag_by_name(_normalize_tag(name))
+    tag = store.get_session_tag_by_name(
+        _normalize_tag(name), project_path=project_path
+    )
     if tag:
         return tag
     # Also try unnormalized (in case title was stored differently)
-    return store.get_session_tag_by_name(name)
+    return store.get_session_tag_by_name(name, project_path=project_path)
 
 
 def get_active_tag(store: Store, project_path: str | None = None) -> dict | None:
@@ -72,7 +80,7 @@ def start_tag(
     if not tag_name:
         raise ValueError("Tag name cannot be empty")
 
-    existing = get_tag(store, tag_name)
+    existing = get_tag(store, tag_name, project_path=project_path)
     if existing:
         extra = existing.get("extra") or {}
         if extra.get("session_status") == "active":
@@ -98,6 +106,7 @@ def start_tag(
         "project_path": project_path or "",
         "started_at": now,
         "paused_at": None,
+        "paused_reason": None,
         "completed_at": None,
         "current_focus": focus,
         "remaining": remaining or [],
@@ -105,15 +114,19 @@ def start_tag(
         "linked_nodes": [],
     }
 
-    nid = store.add_node(
-        title=tag_name,
-        content=description,
-        node_type="session",
-        prov_activity="session-tag",
-        prov_source=project_path or "",
-        prov_who=prov_who or [],
-        extra=extra,
-    )
+    try:
+        nid = store.add_node(
+            title=tag_name,
+            content=description,
+            node_type="session",
+            prov_activity="session-tag",
+            prov_source=project_path or "",
+            prov_who=prov_who or [],
+            extra=extra,
+        )
+    except sqlite3.IntegrityError as exc:
+        store.conn.rollback()
+        raise ValueError(f"Active tag already exists: {tag_name}") from exc
     return nid
 
 
@@ -126,6 +139,7 @@ def update_tag(
     remaining: list[str] | None = None,
     append_remaining: list[str] | None = None,
     remove_remaining: list[str] | None = None,
+    project_path: str | None = None,
 ) -> None:
     """Update the current state of a session tag.
 
@@ -133,7 +147,7 @@ def update_tag(
     extra changes go through Store.atomic_extra_update (fresh read inside
     BEGIN IMMEDIATE — no lost updates from stale snapshots).
     """
-    tag = get_tag(store, name)
+    tag = get_tag(store, name, project_path=project_path)
     if not tag:
         raise ValueError(f"Tag not found: {name}")
 
@@ -171,13 +185,14 @@ def add_segment(
     new_focus: str,
     summary: str = "",
     decisions: list[str] | None = None,
+    project_path: str | None = None,
 ) -> None:
     """Close the current segment and start a new one.
 
     Runs inside Store.atomic_extra_update: a node linked (or a focus set)
     by another agent between this caller's read and write must survive.
     """
-    tag = get_tag(store, name)
+    tag = get_tag(store, name, project_path=project_path)
     if not tag:
         raise ValueError(f"Tag not found: {name}")
 
@@ -212,14 +227,20 @@ def add_segment(
     store.atomic_extra_update(tag["id"], _mutate)
 
 
-def link_node_to_tag(store: Store, tag_name: str, node_id: str) -> None:
+def link_node_to_tag(
+    store: Store,
+    tag_name: str,
+    node_id: str,
+    *,
+    project_path: str | None = None,
+) -> None:
     """Associate a knowledge node with a session tag.
 
     Hooks auto-link every captured node to the project's active tag, so
     multiple agents race on this node: the mutation runs inside
     Store.atomic_extra_update to avoid losing concurrent links/segments.
     """
-    tag = get_tag(store, tag_name)
+    tag = get_tag(store, tag_name, project_path=project_path)
     if not tag:
         return
 
@@ -245,15 +266,22 @@ def link_node_to_tag(store: Store, tag_name: str, node_id: str) -> None:
         pass  # Edge may already exist
 
 
-def pause_tag(store: Store, name: str, *, summary: str = "") -> None:
+def pause_tag(
+    store: Store,
+    name: str,
+    *,
+    summary: str = "",
+    project_path: str | None = None,
+) -> None:
     """Pause a session tag, marking it as suspended."""
-    tag = get_tag(store, name)
+    tag = get_tag(store, name, project_path=project_path)
     if not tag:
         raise ValueError(f"Tag not found: {name}")
 
     def _mutate(extra: dict) -> None:
         extra["session_status"] = "paused"
         extra["paused_at"] = _now()
+        extra["paused_reason"] = "user"
 
         if summary:
             # Update current segment summary
@@ -264,9 +292,15 @@ def pause_tag(store: Store, name: str, *, summary: str = "") -> None:
     store.atomic_extra_update(tag["id"], _mutate)
 
 
-def complete_tag(store: Store, name: str, *, summary: str = "") -> None:
+def complete_tag(
+    store: Store,
+    name: str,
+    *,
+    summary: str = "",
+    project_path: str | None = None,
+) -> None:
     """Mark a session tag as completed."""
-    tag = get_tag(store, name)
+    tag = get_tag(store, name, project_path=project_path)
     if not tag:
         raise ValueError(f"Tag not found: {name}")
 
@@ -286,6 +320,38 @@ def complete_tag(store: Store, name: str, *, summary: str = "") -> None:
     store.atomic_extra_update(tag["id"], _mutate)
 
 
+def resume_tag(
+    store: Store,
+    name: str,
+    *,
+    project_path: str | None = None,
+) -> dict:
+    """Reactivate a paused tag and return its current stored state."""
+    tag = get_tag(store, name, project_path=project_path)
+    if not tag:
+        raise ValueError(f"Tag not found: {name}")
+
+    status = (tag.get("extra") or {}).get("session_status")
+    if status == "completed":
+        raise ValueError(f"Tag is completed; start a new session: {name}")
+    if status == "paused":
+        def _mutate(extra: dict) -> None:
+            extra["session_status"] = "active"
+            extra["paused_at"] = None
+            extra["paused_reason"] = None
+
+        try:
+            store.atomic_extra_update(tag["id"], _mutate)
+        except sqlite3.IntegrityError as exc:
+            store.conn.rollback()
+            raise ValueError(f"Active tag already exists: {name}") from exc
+
+    resumed = store.get_node(tag["id"])
+    if resumed is None:
+        raise ValueError(f"Tag not found: {name}")
+    return resumed
+
+
 def format_resume_context(
     store: Store,
     name: str,
@@ -294,6 +360,7 @@ def format_resume_context(
     counter: Callable[[str], int] | None = None,
     evaluation_time: str | datetime.datetime | None = None,
     trusted_only: bool = True,
+    project_path: str | None = None,
 ) -> str:
     """Generate a deterministic, admission-controlled resume projection.
 
@@ -367,7 +434,7 @@ def format_resume_context(
     if not add_complete(warning):
         return ""
 
-    tag = get_tag(store, name)
+    tag = get_tag(store, name, project_path=project_path)
     if not tag:
         add_labeled("## Session not found: ", name)
         result = rendered()

--- a/src/kindex/store.py
+++ b/src/kindex/store.py
@@ -26,7 +26,30 @@ def _jdumps(obj):
     return json.dumps(obj, default=_json_default)
 
 from .config import Config
-from .schema import ALL_NODE_TYPES, CREATE_TABLES, EDGE_TYPES, SCHEMA_VERSION, edit_class_for
+from .schema import (
+    ALL_NODE_TYPES,
+    CREATE_TABLES,
+    LEGACY_DREAM_DOMAIN_EDGE_PROVENANCE,
+    EDGE_TYPES,
+    SCHEMA_VERSION,
+    SEMANTIC_GRAPH_EXCLUDED_NODE_TYPES,
+    edit_class_for,
+)
+
+_SEMANTIC_NODE_PLACEHOLDERS = ",".join(
+    "?" for _ in SEMANTIC_GRAPH_EXCLUDED_NODE_TYPES
+)
+_NON_DOMAIN_EDGE_SQL = "COALESCE(e.provenance, '') != ?"
+_SEMANTIC_EDGE_SQL = (
+    f"{_NON_DOMAIN_EDGE_SQL} "
+    f"AND source.type NOT IN ({_SEMANTIC_NODE_PLACEHOLDERS}) "
+    f"AND target.type NOT IN ({_SEMANTIC_NODE_PLACEHOLDERS})"
+)
+_SEMANTIC_EDGE_PARAMS = (
+    LEGACY_DREAM_DOMAIN_EDGE_PROVENANCE,
+    *SEMANTIC_GRAPH_EXCLUDED_NODE_TYPES,
+    *SEMANTIC_GRAPH_EXCLUDED_NODE_TYPES,
+)
 
 
 def _now() -> str:
@@ -506,6 +529,9 @@ class Store:
         if current_version < 11:
             self._migrate_v11()
 
+        if current_version < 12:
+            self._migrate_v12()
+
     def _migrate_v8(self) -> None:
         """Atomically upgrade a version-7 store to the state-resilience schema.
 
@@ -780,6 +806,114 @@ class Store:
             c.rollback()
             raise
 
+    def _migrate_v12(self) -> None:
+        """Make active session-tag identity deterministic and race-safe.
+
+        Existing duplicate active rows are preserved as paused history. The
+        most recently updated row remains active, then a partial unique index
+        makes another duplicate for the same normalized tag and project
+        unrepresentable.
+        """
+        c = self._conn
+        c.execute("BEGIN IMMEDIATE")
+        try:
+            node_columns = {
+                row["name"]
+                for row in c.execute("PRAGMA table_info(nodes)").fetchall()
+            }
+            updated_expr = "updated_at" if "updated_at" in node_columns else "''"
+            created_expr = "created_at" if "created_at" in node_columns else "''"
+            rows = c.execute(
+                f"""SELECT id, extra,
+                           {updated_expr} AS updated_at,
+                           {created_expr} AS created_at
+                      FROM nodes
+                     WHERE type = 'session'
+                       AND json_valid(extra)
+                       AND json_extract(extra, '$.session_status') = 'active'
+                       AND json_extract(extra, '$.tag') IS NOT NULL
+                     ORDER BY updated_at DESC, created_at DESC, id DESC"""
+            ).fetchall()
+            active_keys: set[tuple[str, str]] = set()
+            paused_at = _now()
+            for row in rows:
+                extra = json.loads(row["extra"])
+                key = (
+                    str(extra.get("tag") or ""),
+                    str(extra.get("project_path") or ""),
+                )
+                if key not in active_keys:
+                    active_keys.add(key)
+                    continue
+                extra["session_status"] = "paused"
+                extra["paused_at"] = extra.get("paused_at") or paused_at
+                extra["paused_reason"] = "duplicate-active-session-migration-v12"
+                c.execute(
+                    "UPDATE nodes SET extra = ? WHERE id = ?",
+                    (_jdumps(extra), row["id"]),
+                )
+
+            c.execute(
+                """CREATE UNIQUE INDEX IF NOT EXISTS idx_session_active_tag_project
+                       ON nodes (
+                           json_extract(extra, '$.tag'),
+                           COALESCE(json_extract(extra, '$.project_path'), '')
+                       )
+                     WHERE type = 'session'
+                       AND json_valid(extra)
+                       AND json_extract(extra, '$.session_status') = 'active'"""
+            )
+            has_suggestions = c.execute(
+                """SELECT 1 FROM sqlite_master
+                     WHERE type = 'table' AND name = 'suggestions'"""
+            ).fetchone()
+            if has_suggestions is not None:
+                c.execute(
+                    """CREATE INDEX IF NOT EXISTS idx_suggestions_pair
+                           ON suggestions(concept_a, concept_b)"""
+                )
+            duplicate = c.execute(
+                """SELECT 1 FROM nodes
+                     WHERE type = 'session'
+                       AND json_valid(extra)
+                       AND json_extract(extra, '$.session_status') = 'active'
+                     GROUP BY json_extract(extra, '$.tag'),
+                              COALESCE(json_extract(extra, '$.project_path'), '')
+                    HAVING COUNT(*) > 1
+                     LIMIT 1"""
+            ).fetchone()
+            if duplicate is not None:
+                raise RuntimeError(
+                    "v12 migration verification failed: duplicate active session tags"
+                )
+            index = c.execute(
+                """SELECT 1 FROM sqlite_master
+                     WHERE type = 'index'
+                       AND name = 'idx_session_active_tag_project'"""
+            ).fetchone()
+            if index is None:
+                raise RuntimeError(
+                    "v12 migration verification failed: active session index"
+                )
+            if has_suggestions is not None:
+                suggestion_index = c.execute(
+                    """SELECT 1 FROM sqlite_master
+                         WHERE type = 'index'
+                           AND name = 'idx_suggestions_pair'"""
+                ).fetchone()
+                if suggestion_index is None:
+                    raise RuntimeError(
+                        "v12 migration verification failed: suggestion pair index"
+                    )
+            c.execute(
+                "UPDATE meta SET value = ? WHERE key = 'schema_version'",
+                ("12",),
+            )
+            c.commit()
+        except BaseException:
+            c.rollback()
+            raise
+
     # Columns each table must carry for the code that queries it to work.
     # Checked by `kin doctor`, which is the only place that catches the failure
     # class v10 repairs: a table that exists with the right name and the wrong
@@ -971,19 +1105,27 @@ class Store:
         concept_a: str,
         concept_b: str,
         *,
-        status: str = "pending",
+        status: str | None = "pending",
     ) -> bool:
         """Return true if a suggestion exists for this pair in either order."""
+        status_clause = "status = ? AND " if status is not None else ""
+        params: tuple[Any, ...]
+        if status is None:
+            params = (concept_a, concept_b, concept_b, concept_a)
+        else:
+            params = (status, concept_a, concept_b, status, concept_b, concept_a)
         row = self.conn.execute(
-            """
+            f"""
             SELECT 1 FROM suggestions
-             WHERE status = ? AND kind = 'bridge' AND concept_a = ? AND concept_b = ?
+             WHERE {status_clause}kind = 'bridge'
+               AND concept_a = ? AND concept_b = ?
             UNION ALL
             SELECT 1 FROM suggestions
-             WHERE status = ? AND kind = 'bridge' AND concept_a = ? AND concept_b = ?
+             WHERE {status_clause}kind = 'bridge'
+               AND concept_a = ? AND concept_b = ?
             LIMIT 1
             """,
-            (status, concept_a, concept_b, status, concept_b, concept_a),
+            params,
         ).fetchone()
         return row is not None
 
@@ -1041,14 +1183,36 @@ class Store:
         now = _now()
         when = prov_when or now
         self.conn.execute(
-            """INSERT OR REPLACE INTO nodes
+            """INSERT INTO nodes
                (id, type, title, content, aka, intent,
                 prov_who, prov_when, prov_activity, prov_why, prov_source,
                 weight, domains, status, audience,
                 created_at, updated_at, last_accessed, extra,
                 referent, asserted_at, true_of)
                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
-                       ?, ?, ?)""",
+                       ?, ?, ?)
+               ON CONFLICT(id) DO UPDATE SET
+                   type = excluded.type,
+                   title = excluded.title,
+                   content = excluded.content,
+                   aka = excluded.aka,
+                   intent = excluded.intent,
+                   prov_who = excluded.prov_who,
+                   prov_when = excluded.prov_when,
+                   prov_activity = excluded.prov_activity,
+                   prov_why = excluded.prov_why,
+                   prov_source = excluded.prov_source,
+                   weight = excluded.weight,
+                   domains = excluded.domains,
+                   status = excluded.status,
+                   audience = excluded.audience,
+                   created_at = excluded.created_at,
+                   updated_at = excluded.updated_at,
+                   last_accessed = excluded.last_accessed,
+                   extra = excluded.extra,
+                   referent = excluded.referent,
+                   asserted_at = excluded.asserted_at,
+                   true_of = excluded.true_of""",
             (nid, node_type, title, content,
              _jdumps(aka or []), intent,
              _jdumps(prov_who or []), when, prov_activity, prov_why, prov_source,
@@ -1195,6 +1359,7 @@ class Store:
                   status: str | None = None,
                   audience: str | None = None,
                   tags: list[str] | None = None,
+                  exclude_types: tuple[str, ...] = (),
                   limit: int = 500) -> list[dict]:
         """List nodes with optional type/status/audience/tags filters."""
         q = "SELECT * FROM nodes WHERE 1=1"
@@ -1212,7 +1377,11 @@ class Store:
             for tag in tags:
                 q += " AND domains LIKE ?"
                 params.append(f'%"{tag}"%')
-        q += " ORDER BY weight DESC, updated_at DESC LIMIT ?"
+        if exclude_types:
+            placeholders = ",".join("?" for _ in exclude_types)
+            q += f" AND type NOT IN ({placeholders})"
+            params.extend(exclude_types)
+        q += " ORDER BY weight DESC, updated_at DESC, id ASC LIMIT ?"
         params.append(limit)
         rows = self.conn.execute(q, params).fetchall()
         return [self._row_to_dict(r) for r in rows]
@@ -2617,9 +2786,12 @@ class Store:
             placeholders = ",".join("?" for _ in frontier)
             try:
                 rows = self.conn.execute(
-                    f"""SELECT from_id, to_id, weight FROM edges
-                        WHERE from_id IN ({placeholders})""",
-                    tuple(frontier),
+                    f"""SELECT e.from_id, e.to_id, e.weight FROM edges e
+                          JOIN nodes source ON source.id = e.from_id
+                          JOIN nodes target ON target.id = e.to_id
+                         WHERE e.from_id IN ({placeholders})
+                           AND {_SEMANTIC_EDGE_SQL}""",
+                    (*frontier, *_SEMANTIC_EDGE_PARAMS),
                 ).fetchall()
             except Exception:
                 break
@@ -2647,31 +2819,96 @@ class Store:
 
         return sorted(best.items(), key=lambda kv: (-kv[1], kv[0]))
 
-    def edges_from(self, node_id: str) -> list[dict]:
-        rows = self.conn.execute(
-            """SELECT e.*, n.title as to_title FROM edges e
-               JOIN nodes n ON n.id = e.to_id
-               WHERE e.from_id = ? ORDER BY e.weight DESC""",
-            (node_id,),
-        ).fetchall()
+    def edges_from(self, node_id: str, *, semantic_only: bool = False) -> list[dict]:
+        q = """SELECT e.*, target.title as to_title FROM edges e
+                 JOIN nodes source ON source.id = e.from_id
+                 JOIN nodes target ON target.id = e.to_id
+                WHERE e.from_id = ?"""
+        params: list[Any] = [node_id]
+        if semantic_only:
+            q += f" AND {_SEMANTIC_EDGE_SQL}"
+            params.extend(_SEMANTIC_EDGE_PARAMS)
+        q += " ORDER BY e.weight DESC"
+        rows = self.conn.execute(q, params).fetchall()
         return [dict(r) for r in rows]
 
-    def edges_to(self, node_id: str) -> list[dict]:
-        rows = self.conn.execute(
-            """SELECT e.*, n.title as from_title FROM edges e
-               JOIN nodes n ON n.id = e.from_id
-               WHERE e.to_id = ? ORDER BY e.weight DESC""",
-            (node_id,),
-        ).fetchall()
+    def edges_to(self, node_id: str, *, semantic_only: bool = False) -> list[dict]:
+        q = """SELECT e.*, source.title as from_title FROM edges e
+                 JOIN nodes source ON source.id = e.from_id
+                 JOIN nodes target ON target.id = e.to_id
+                WHERE e.to_id = ?"""
+        params: list[Any] = [node_id]
+        if semantic_only:
+            q += f" AND {_SEMANTIC_EDGE_SQL}"
+            params.extend(_SEMANTIC_EDGE_PARAMS)
+        q += " ORDER BY e.weight DESC"
+        rows = self.conn.execute(q, params).fetchall()
         return [dict(r) for r in rows]
 
     def orphans(self) -> list[dict]:
-        """Nodes with no edges (violates graph health invariant)."""
+        """Semantic nodes with no semantic edges."""
         rows = self.conn.execute(
-            """SELECT * FROM nodes WHERE id NOT IN
-               (SELECT from_id FROM edges UNION SELECT to_id FROM edges)"""
+            f"""SELECT n.* FROM nodes n
+                  WHERE n.type NOT IN ({_SEMANTIC_NODE_PLACEHOLDERS})
+                    AND NOT EXISTS (
+                        SELECT 1 FROM edges e
+                        JOIN nodes source ON source.id = e.from_id
+                        JOIN nodes target ON target.id = e.to_id
+                        WHERE e.from_id = n.id
+                          AND {_SEMANTIC_EDGE_SQL}
+                    )
+                    AND NOT EXISTS (
+                        SELECT 1 FROM edges e
+                        JOIN nodes source ON source.id = e.from_id
+                        JOIN nodes target ON target.id = e.to_id
+                        WHERE e.to_id = n.id
+                          AND {_SEMANTIC_EDGE_SQL}
+                    )""",
+            (
+                *SEMANTIC_GRAPH_EXCLUDED_NODE_TYPES,
+                *_SEMANTIC_EDGE_PARAMS,
+                *_SEMANTIC_EDGE_PARAMS,
+            ),
         ).fetchall()
         return [self._row_to_dict(r) for r in rows]
+
+    def graph_edge_counts(self) -> dict[str, int]:
+        """Count stored and semantic edges without conflating derived topology."""
+        stored = self.conn.execute("SELECT COUNT(*) FROM edges").fetchone()[0]
+        domain = self.conn.execute(
+            "SELECT COUNT(*) FROM edges WHERE provenance = ?",
+            (LEGACY_DREAM_DOMAIN_EDGE_PROVENANCE,),
+        ).fetchone()[0]
+        semantic = self.conn.execute(
+            f"""SELECT COUNT(*) FROM edges e
+                  JOIN nodes source ON source.id = e.from_id
+                  JOIN nodes target ON target.id = e.to_id
+                 WHERE {_SEMANTIC_EDGE_SQL}""",
+            _SEMANTIC_EDGE_PARAMS,
+        ).fetchone()[0]
+        session = self.conn.execute(
+            f"""SELECT COUNT(*) FROM edges e
+                  JOIN nodes source ON source.id = e.from_id
+                  JOIN nodes target ON target.id = e.to_id
+                 WHERE {_NON_DOMAIN_EDGE_SQL}
+                   AND (
+                       source.type IN ({_SEMANTIC_NODE_PLACEHOLDERS})
+                       OR target.type IN ({_SEMANTIC_NODE_PLACEHOLDERS})
+                   )""",
+            (
+                LEGACY_DREAM_DOMAIN_EDGE_PROVENANCE,
+                *SEMANTIC_GRAPH_EXCLUDED_NODE_TYPES,
+                *SEMANTIC_GRAPH_EXCLUDED_NODE_TYPES,
+            ),
+        ).fetchone()[0]
+        other = stored - semantic - domain - session
+        return {
+            "stored": stored,
+            "semantic": semantic,
+            "domain": domain,
+            "session": session,
+            "other": other,
+        }
 
     # ── FTS5 search ────────────────────────────────────────────────────
 
@@ -3300,34 +3537,49 @@ class Store:
         project_path: str | None = None,
         limit: int = 20,
     ) -> list[dict]:
-        """Query session-tag nodes with optional status and project_path filters."""
-        q = "SELECT * FROM nodes WHERE type = 'session' AND extra LIKE ?"
-        params: list = ['%"session_status"%']
-        if project_path:
-            q += " AND extra LIKE ?"
-            params.append(f'%"project_path"%"{project_path}"%')
-        q += " ORDER BY updated_at DESC LIMIT ?"
+        """Query session tags, applying exact filters before ordering and limit."""
+        q = """SELECT * FROM nodes
+                WHERE type = 'session'
+                  AND json_valid(extra)
+                  AND json_extract(extra, '$.session_status') IS NOT NULL"""
+        params: list[Any] = []
+        if status:
+            q += " AND json_extract(extra, '$.session_status') = ?"
+            params.append(status)
+        if project_path is not None:
+            q += " AND COALESCE(json_extract(extra, '$.project_path'), '') = ?"
+            params.append(project_path)
+        q += " ORDER BY updated_at DESC, created_at DESC, id DESC LIMIT ?"
         params.append(limit)
         rows = self.conn.execute(q, params).fetchall()
-        results = [self._row_to_dict(r) for r in rows]
-        if status:
-            results = [
-                r for r in results
-                if (r.get("extra") or {}).get("session_status") == status
-            ]
-        return results
+        return [self._row_to_dict(r) for r in rows]
 
-    def get_session_tag_by_name(self, tag_name: str) -> dict | None:
-        """Find a session tag by its tag name in extra JSON."""
-        rows = self.conn.execute(
-            "SELECT * FROM nodes WHERE type = 'session' AND extra LIKE ?",
-            (f'%"tag"%"{tag_name}"%',),
-        ).fetchall()
-        for r in rows:
-            d = self._row_to_dict(r)
-            if (d.get("extra") or {}).get("tag") == tag_name:
-                return d
-        return self.get_node_by_title(tag_name)
+    def get_session_tag_by_name(
+        self,
+        tag_name: str,
+        *,
+        project_path: str | None = None,
+    ) -> dict | None:
+        """Find the current session tag with an exact, deterministic lookup."""
+        q = """SELECT * FROM nodes
+                WHERE type = 'session'
+                  AND json_valid(extra)
+                  AND json_extract(extra, '$.tag') = ?"""
+        params: list[Any] = [tag_name]
+        if project_path is not None:
+            q += " AND COALESCE(json_extract(extra, '$.project_path'), '') = ?"
+            params.append(project_path)
+        q += """ ORDER BY
+                    CASE json_extract(extra, '$.session_status')
+                        WHEN 'active' THEN 0
+                        WHEN 'paused' THEN 1
+                        WHEN 'completed' THEN 2
+                        ELSE 3
+                    END,
+                    updated_at DESC, created_at DESC, id DESC
+                  LIMIT 1"""
+        row = self.conn.execute(q, params).fetchone()
+        return self._row_to_dict(row) if row is not None else None
 
     def active_watches(self) -> list[dict]:
         """Get all active watches that haven't expired."""
@@ -3694,15 +3946,32 @@ class Store:
     # ── Stats ──────────────────────────────────────────────────────────
 
     def stats(self) -> dict:
-        node_count = self.conn.execute("SELECT COUNT(*) FROM nodes").fetchone()[0]
-        edge_count = self.conn.execute("SELECT COUNT(*) FROM edges").fetchone()[0]
+        stored_node_count = self.conn.execute(
+            "SELECT COUNT(*) FROM nodes"
+        ).fetchone()[0]
+        placeholders = ",".join(
+            "?" for _ in SEMANTIC_GRAPH_EXCLUDED_NODE_TYPES
+        )
+        semantic_node_count = self.conn.execute(
+            f"SELECT COUNT(*) FROM nodes WHERE type NOT IN ({placeholders})",
+            SEMANTIC_GRAPH_EXCLUDED_NODE_TYPES,
+        ).fetchone()[0]
+        edge_counts = self.graph_edge_counts()
         orphan_count = len(self.orphans())
         type_counts = {}
         for row in self.conn.execute("SELECT type, COUNT(*) as c FROM nodes GROUP BY type"):
             type_counts[row["type"]] = row["c"]
         return {
-            "nodes": node_count,
-            "edges": edge_count,
+            # ``nodes`` remains as a compatibility alias, but it now has the
+            # same semantic meaning as graph.store_stats().
+            "nodes": semantic_node_count,
+            "semantic_nodes": semantic_node_count,
+            "stored_nodes": stored_node_count,
+            "edges": edge_counts["semantic"],
+            "stored_edges": edge_counts["stored"],
+            "ignored_domain_edges": edge_counts["domain"],
+            "ignored_session_edges": edge_counts["session"],
+            "ignored_other_edges": edge_counts["other"],
             "orphans": orphan_count,
             "types": type_counts,
         }

--- a/src/kindex/tasks.py
+++ b/src/kindex/tasks.py
@@ -366,9 +366,9 @@ def store_bfs(
             continue
 
         # Follow edges in both directions
-        edges = store.edges_from(node_id)
+        edges = store.edges_from(node_id, semantic_only=True)
         try:
-            edges += store.edges_to(node_id)
+            edges += store.edges_to(node_id, semantic_only=True)
         except AttributeError:
             pass
 

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -47,7 +47,7 @@ class TestFindArchivable:
         ids = find_archivable_nodes(store)
         assert "active1" not in ids  # status is still 'active'
 
-    def test_skips_session_types(self, setup):
+    def test_skips_active_session_types(self, setup):
         from kindex.archive import find_archivable_nodes
 
         cfg, store = setup
@@ -60,6 +60,53 @@ class TestFindArchivable:
 
         ids = find_archivable_nodes(store)
         assert "sess1" not in ids
+
+    def test_finds_completed_unlinked_session(self, setup):
+        from kindex.archive import find_archivable_nodes
+        from kindex.sessions import complete_tag, start_tag
+
+        cfg, store = setup
+        session_id = start_tag(store, "finished-session")
+        complete_tag(store, "finished-session")
+        store.conn.execute(
+            "UPDATE nodes SET updated_at = '2025-01-01T00:00:00' WHERE id = ?",
+            (session_id,),
+        )
+        store.conn.commit()
+
+        assert session_id in find_archivable_nodes(store)
+
+    def test_skips_paused_session(self, setup):
+        from kindex.archive import find_archivable_nodes
+        from kindex.sessions import pause_tag, start_tag
+
+        cfg, store = setup
+        session_id = start_tag(store, "paused-session")
+        pause_tag(store, "paused-session")
+        store.conn.execute(
+            "UPDATE nodes SET updated_at = '2025-01-01T00:00:00' WHERE id = ?",
+            (session_id,),
+        )
+        store.conn.commit()
+
+        assert session_id not in find_archivable_nodes(store)
+
+    def test_skips_completed_session_with_linked_knowledge(self, setup):
+        from kindex.archive import find_archivable_nodes
+        from kindex.sessions import complete_tag, link_node_to_tag, start_tag
+
+        cfg, store = setup
+        session_id = start_tag(store, "linked-session")
+        node_id = store.add_node("Session knowledge")
+        link_node_to_tag(store, "linked-session", node_id)
+        complete_tag(store, "linked-session")
+        store.conn.execute(
+            "UPDATE nodes SET updated_at = '2025-01-01T00:00:00' WHERE id = ?",
+            (session_id,),
+        )
+        store.conn.commit()
+
+        assert session_id not in find_archivable_nodes(store)
 
     def test_empty_store(self, setup):
         from kindex.archive import find_archivable_nodes
@@ -223,6 +270,21 @@ class TestRestoreNode:
         # Edge should be restored since b1 is still in fast graph
         edges = store.edges_from("a1")
         assert len(edges) >= 1
+
+    def test_restore_preserves_completed_session_history(self, setup):
+        from kindex.archive import archive_nodes, restore_node
+        from kindex.sessions import complete_tag, start_tag
+
+        cfg, store = setup
+        session_id = start_tag(store, "session-history", focus="Done work")
+        complete_tag(store, "session-history", summary="Finished")
+        archive_nodes(cfg, store, [session_id])
+
+        assert restore_node(cfg, store, session_id)
+        restored = store.get_node(session_id)
+        assert restored["type"] == "session"
+        assert restored["extra"]["session_status"] == "completed"
+        assert restored["extra"]["segments"][0]["summary"] == "Finished"
 
 
 class TestRotation:

--- a/tests/test_atomic_rmw.py
+++ b/tests/test_atomic_rmw.py
@@ -202,7 +202,7 @@ class TestSessionTagAtomicity:
         sessions.link_node_to_tag(store, self.TAG, nid)  # rival commit
 
         with monkeypatch.context() as m:
-            m.setattr(sessions, "get_tag", lambda s, n: _stale(stale))
+            m.setattr(sessions, "get_tag", lambda s, n, **_: _stale(stale))
             sessions.add_segment(store, self.TAG, new_focus="next topic",
                                  summary="first part done")
 
@@ -222,7 +222,7 @@ class TestSessionTagAtomicity:
         nid = store.add_node("Captured by A")
 
         with monkeypatch.context() as m:
-            m.setattr(sessions, "get_tag", lambda s, n: _stale(stale))
+            m.setattr(sessions, "get_tag", lambda s, n, **_: _stale(stale))
             sessions.link_node_to_tag(store, self.TAG, nid)
 
         extra = _fresh_extra(store, tag["id"])
@@ -238,7 +238,7 @@ class TestSessionTagAtomicity:
         sessions.link_node_to_tag(store, self.TAG, nid)
 
         with monkeypatch.context() as m:
-            m.setattr(sessions, "get_tag", lambda s, n: _stale(stale))
+            m.setattr(sessions, "get_tag", lambda s, n, **_: _stale(stale))
             sessions.update_tag(store, self.TAG, focus="refocus",
                                 append_remaining=["todo-x"])
 
@@ -254,7 +254,7 @@ class TestSessionTagAtomicity:
         sessions.link_node_to_tag(store, self.TAG, nid)
 
         with monkeypatch.context() as m:
-            m.setattr(sessions, "get_tag", lambda s, n: _stale(stale))
+            m.setattr(sessions, "get_tag", lambda s, n, **_: _stale(stale))
             sessions.pause_tag(store, self.TAG, summary="pausing")
 
         extra = _fresh_extra(store, tag["id"])
@@ -268,7 +268,7 @@ class TestSessionTagAtomicity:
         sessions.link_node_to_tag(store, self.TAG, nid)
 
         with monkeypatch.context() as m:
-            m.setattr(sessions, "get_tag", lambda s, n: _stale(stale))
+            m.setattr(sessions, "get_tag", lambda s, n, **_: _stale(stale))
             sessions.complete_tag(store, self.TAG, summary="all done")
 
         extra = _fresh_extra(store, tag["id"])

--- a/tests/test_dream.py
+++ b/tests/test_dream.py
@@ -266,6 +266,27 @@ class TestDreamLightweight:
         assert results["suggestion_existing"] == 1
         assert row["count"] == 1
 
+    def test_does_not_recreate_resolved_suggestion(self, config, store, monkeypatch):
+        import kindex.dream as dream
+
+        a = store.add_node("Alpha anchor")
+        b = store.add_node("Alpha anchored")
+        suggestion_id = store.add_suggestion(a, b, source="dream-cycle")
+        store.update_suggestion(suggestion_id, "rejected")
+        monkeypatch.setattr(
+            dream,
+            "find_duplicates",
+            lambda _store: {"merge": [], "suggest": [(a, b, 0.9)]},
+        )
+
+        results = dream.dream_lightweight(config, store)
+
+        assert results["suggested"] == 0
+        assert results["suggestion_existing"] == 1
+        assert store.conn.execute(
+            "SELECT COUNT(*) FROM suggestions"
+        ).fetchone()[0] == 1
+
     def test_caps_new_suggestion_writes(self, config, store, monkeypatch):
         import kindex.dream as dream
 
@@ -296,7 +317,8 @@ class TestDreamFull:
         from kindex.dream import dream_full
         results = dream_full(config, store)
         assert results["merged"] == 0
-        assert results["edges_strengthened"] == 0
+        assert results["domain_link_suggestions_created"] == 0
+        assert results["domain_link_proposals"] == []
 
 
 class TestDreamCycle:
@@ -435,42 +457,236 @@ class TestProtectedTypes:
         assert len(result["merge"]) == 0
 
 
-# ── Domain edge strengthening ────────────────────────────────────────
+# ── Domain link proposals ────────────────────────────────────────────
 
 
-class TestDomainEdges:
-    def test_creates_edges_for_shared_domain(self, store):
-        from kindex.dream import strengthen_domain_edges
+class TestDomainLinkProposals:
+    def test_proposes_sparse_representative_links(self, store):
+        from kindex.dream import propose_domain_links
+
+        ids = [
+            store.add_node(f"Concept {index}", domains=["security"])
+            for index in range(5)
+        ]
+
+        proposals, capped = propose_domain_links(store, limit=20)
+
+        assert len(proposals) == len(ids) - 1
+        assert capped is False
+        assert len({proposal["from_id"] for proposal in proposals}) == 1
+        assert store.conn.execute("SELECT COUNT(*) FROM edges").fetchone()[0] == 0
+
+    def test_proposal_budget_is_hard_and_deterministic(self, store):
+        from kindex.dream import propose_domain_links
+
+        for index in range(10):
+            store.add_node(f"Concept {index}", domains=["security"])
+
+        first, first_capped = propose_domain_links(store, limit=3)
+        second, second_capped = propose_domain_links(store, limit=3)
+
+        assert first == second
+        assert len(first) == 3
+        assert first_capped is second_capped is True
+
+    def test_proposal_budget_round_robins_across_domains(self, store):
+        from kindex.dream import propose_domain_links
+
+        for domain in ("alpha", "beta", "gamma"):
+            for index in range(3):
+                store.add_node(
+                    f"{domain} {index}",
+                    node_id=f"{domain}-{index}",
+                    domains=[domain],
+                )
+
+        proposals, capped = propose_domain_links(store, limit=3)
+
+        assert [proposal["domain"] for proposal in proposals] == [
+            "alpha",
+            "beta",
+            "gamma",
+        ]
+        assert capped is True
+
+    def test_representative_is_stable_when_weights_change(self, store):
+        from kindex.dream import propose_domain_links
+
+        store.add_node("First", node_id="a", domains=["security"], weight=0.1)
+        store.add_node("Second", node_id="b", domains=["security"], weight=0.9)
+        store.add_node("Third", node_id="c", domains=["security"], weight=0.5)
+        before, _ = propose_domain_links(store)
+
+        store.update_node("a", weight=1.0)
+        store.update_node("b", weight=0.01)
+        store.update_node("c", weight=0.02)
+        after, _ = propose_domain_links(store)
+
+        assert before == after
+        assert {proposal["from_id"] for proposal in after} == {"a"}
+
+    def test_full_dry_run_reports_pairs_without_writes(self, config, store):
+        from kindex.dream import dream_full
+
         store.add_node("Concept A", domains=["security"])
         store.add_node("Concept B", domains=["security"])
 
-        created = strengthen_domain_edges(store)
-        assert created >= 1
+        results = dream_full(config, store, dry_run=True)
 
-    def test_dry_run_counts_without_creating(self, store):
-        from kindex.dream import strengthen_domain_edges
-        store.add_node("Concept A", domains=["security"])
-        store.add_node("Concept B", domains=["security"])
+        assert len(results["domain_link_proposals"]) == 1
+        assert results["domain_link_suggestions_created"] == 0
+        assert store.conn.execute("SELECT COUNT(*) FROM edges").fetchone()[0] == 0
+        assert store.conn.execute(
+            "SELECT COUNT(*) FROM suggestions"
+        ).fetchone()[0] == 0
 
-        created = strengthen_domain_edges(store, dry_run=True)
-        assert created >= 1
+    def test_full_creates_reviewable_suggestion_not_edge(self, config, store):
+        from kindex.dream import DOMAIN_SUGGESTION_SOURCE, dream_full
 
-        # No actual edges should exist
-        nodes = store.all_nodes(status="active")
-        for n in nodes:
-            edges = store.edges_from(n["id"])
-            # Filter to only dream-created edges
-            dream_edges = [e for e in edges if "dream" in (e.get("provenance") or "")]
-            assert len(dream_edges) == 0
-
-    def test_skips_already_linked(self, store):
-        from kindex.dream import strengthen_domain_edges
         a = store.add_node("Concept A", domains=["security"])
         b = store.add_node("Concept B", domains=["security"])
-        store.add_edge(a, b, edge_type="relates_to")
 
-        created = strengthen_domain_edges(store)
-        assert created == 0
+        first = dream_full(config, store)
+        second = dream_full(config, store)
+
+        assert first["domain_link_suggestions_created"] == 1
+        assert second["domain_link_suggestions_created"] == 0
+        assert store.conn.execute("SELECT COUNT(*) FROM edges").fetchone()[0] == 0
+        suggestion = store.conn.execute(
+            "SELECT * FROM suggestions WHERE concept_a IN (?, ?)", (a, b)
+        ).fetchone()
+        assert suggestion["source"] == DOMAIN_SUGGESTION_SOURCE
+
+    def test_domain_suggestions_are_never_auto_applied(self, store):
+        from kindex.dream import DOMAIN_SUGGESTION_SOURCE, auto_apply_suggestions
+
+        a = store.add_node("Matching concept")
+        b = store.add_node("Matching concept details")
+        store.add_suggestion(a, b, source=DOMAIN_SUGGESTION_SOURCE)
+
+        assert auto_apply_suggestions(store) == 0
+        assert store.conn.execute("SELECT COUNT(*) FROM edges").fetchone()[0] == 0
+
+    def test_pending_domain_queue_has_a_global_cap(self, config, store):
+        from kindex.dream import DOMAIN_SUGGESTION_SOURCE, dream_full
+
+        config.reminders.dream_max_domain_link_suggestions = 3
+        for index in range(10):
+            store.add_node(f"Concept {index}", domains=["security"])
+
+        first = dream_full(config, store)
+        second = dream_full(config, store)
+
+        assert first["domain_link_suggestions_created"] == 3
+        assert second["domain_link_suggestions_created"] == 0
+        assert second["domain_link_suggestions_pending"] == 3
+        pending = store.conn.execute(
+            "SELECT COUNT(*) FROM suggestions WHERE status = 'pending' AND source = ?",
+            (DOMAIN_SUGGESTION_SOURCE,),
+        ).fetchone()[0]
+        assert pending == 3
+
+    def test_rejected_domain_pair_is_not_reproposed(self, config, store):
+        from kindex.dream import dream_full
+
+        store.add_node("Concept A", node_id="a", domains=["security"])
+        store.add_node("Concept B", node_id="b", domains=["security"])
+        first = dream_full(config, store)
+        suggestion = store.pending_suggestions()[0]
+        store.update_suggestion(suggestion["id"], "rejected")
+
+        second = dream_full(config, store)
+
+        assert first["domain_link_suggestions_created"] == 1
+        assert second["domain_link_proposals"] == []
+        assert second["domain_link_suggestions_created"] == 0
+
+
+class TestDeepDreamClusters:
+    def test_overlap_dedup_removes_subsets_and_near_duplicates(self):
+        from kindex.dream_deep import _dedupe_overlapping_clusters
+
+        def cluster(*ids):
+            return [{"id": node_id} for node_id in ids]
+
+        clusters = [
+            cluster("a", "b", "c", "d", "e"),
+            cluster("a", "b", "c", "d"),
+            cluster("a", "b", "c", "d", "f"),
+            cluster("w", "x", "y", "z"),
+        ]
+
+        deduped = _dedupe_overlapping_clusters(clusters)
+
+        assert [[node["id"] for node in group] for group in deduped] == [
+            ["a", "b", "c", "d", "e"],
+            ["w", "x", "y", "z"],
+        ]
+
+    def test_existing_domain_edges_do_not_create_clusters(self, store):
+        from kindex.dream_deep import _find_clusters
+        from kindex.schema import LEGACY_DREAM_DOMAIN_EDGE_PROVENANCE
+
+        ids = [
+            store.add_node(f"Concept {index}", domains=["security"])
+            for index in range(4)
+        ]
+        for index in range(len(ids) - 1):
+            store.add_edge(
+                ids[index],
+                ids[index + 1],
+                provenance=LEGACY_DREAM_DOMAIN_EDGE_PROVENANCE,
+            )
+
+        assert _find_clusters(store, min_size=4, max_hops=2) == []
+
+    def test_cluster_signature_prevents_regeneration(self, config, store, monkeypatch):
+        import kindex.dream_deep as deep
+
+        cluster = [
+            store.get_node(store.add_node(f"Node {index}"))
+            for index in range(4)
+        ]
+        calls = []
+        monkeypatch.setattr(deep, "_find_clusters", lambda *args, **kwargs: [cluster])
+
+        def summarise(_cluster, timeout=300):
+            calls.append(timeout)
+            return {"title": f"Summary {len(calls)}", "content": "Summary"}
+
+        monkeypatch.setattr(deep, "_llm_summarise_cluster", summarise)
+
+        first = deep.dream_deep(config, store)
+        second = deep.dream_deep(config, store)
+
+        assert first["cluster_summaries"] == 1
+        assert second["cluster_summaries"] == 0
+        assert len(calls) == 1
+
+    def test_existing_overlapping_summary_prevents_regeneration(
+        self, config, store, monkeypatch
+    ):
+        import kindex.dream_deep as deep
+
+        cluster = [
+            store.get_node(store.add_node(f"Node {index}", node_id=f"node-{index}"))
+            for index in range(5)
+        ]
+        store.add_node(
+            "Existing summary",
+            prov_source=deep.CLUSTER_SUMMARY_SOURCE,
+            extra={"cluster_members": [f"node-{index}" for index in range(4)]},
+        )
+        monkeypatch.setattr(deep, "_find_clusters", lambda *args, **kwargs: [cluster])
+        monkeypatch.setattr(
+            deep,
+            "_llm_summarise_cluster",
+            lambda *_args, **_kwargs: pytest.fail("overlapping cluster regenerated"),
+        )
+
+        result = deep.dream_deep(config, store)
+
+        assert result["cluster_summaries"] == 0
 
 
 # ── Protected types: managed/additive state survives dream (idx 25) ──

--- a/tests/test_graph_store.py
+++ b/tests/test_graph_store.py
@@ -55,6 +55,32 @@ class TestBuildNX:
         assert G.number_of_nodes() == 0
         s.close()
 
+    def test_excludes_sessions_and_derived_domain_edges(self, store):
+        from kindex.schema import LEGACY_DREAM_DOMAIN_EDGE_PROVENANCE
+
+        store.add_node("Session", node_id="session", node_type="session")
+        store.add_edge("hub", "session", provenance="session-tag")
+        store.add_edge(
+            "a", "b", provenance=LEGACY_DREAM_DOMAIN_EDGE_PROVENANCE
+        )
+
+        graph = build_nx_from_store(store)
+
+        assert "session" not in graph
+        assert not graph.has_edge("a", "b")
+        assert graph.has_edge("hub", "a")
+
+    def test_semantic_edge_reads_exclude_session_at_either_endpoint(self, store):
+        store.add_node("Session", node_id="session", node_type="session")
+        store.add_edge("hub", "session", provenance="session-tag")
+
+        assert all(
+            edge["to_id"] != "session"
+            for edge in store.edges_from("hub", semantic_only=True)
+        )
+        assert store.edges_from("session", semantic_only=True) == []
+        assert store.edges_to("session", semantic_only=True) == []
+
 
 class TestStoreStats:
     def test_stats(self, store):
@@ -72,6 +98,41 @@ class TestStoreStats:
         stats = store_stats(s)
         assert stats["nodes"] == 0
         s.close()
+
+    def test_reports_stored_topology_separately(self, store):
+        from kindex.schema import LEGACY_DREAM_DOMAIN_EDGE_PROVENANCE
+
+        store.add_node("Session", node_id="session", node_type="session")
+        store.add_edge("hub", "session", provenance="session-tag")
+        store.add_edge(
+            "a", "b", provenance=LEGACY_DREAM_DOMAIN_EDGE_PROVENANCE
+        )
+
+        stats = store_stats(store)
+
+        assert stats["nodes"] == 5
+        assert stats["semantic_nodes"] == 5
+        assert stats["stored_nodes"] == 6
+        assert stats["stored_edges"] > stats["edges"]
+        assert stats["ignored_domain_edges"] == 2
+        assert stats["ignored_session_edges"] == 2
+
+    def test_orphans_ignore_session_and_domain_only_links(self, store):
+        from kindex.schema import LEGACY_DREAM_DOMAIN_EDGE_PROVENANCE
+
+        store.add_node("Session", node_id="session", node_type="session")
+        store.add_node("Domain only", node_id="domain-only")
+        store.add_node("Peer", node_id="peer")
+        store.add_edge(
+            "domain-only",
+            "peer",
+            provenance=LEGACY_DREAM_DOMAIN_EDGE_PROVENANCE,
+        )
+
+        orphan_ids = {node["id"] for node in store.orphans()}
+
+        assert "session" not in orphan_ids
+        assert {"domain-only", "peer"} <= orphan_ids
 
 
 class TestCentrality:

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -190,6 +190,47 @@ class TestCaptureSessionEnd:
         gnn_nodes = [n for n in store.all_nodes() if "graph neural" in n["title"].lower()]
         assert len(gnn_nodes) == 1  # should not create a duplicate
 
+    def test_capture_links_nodes_to_same_project_tag(
+        self, store, config, ledger, monkeypatch, tmp_path
+    ):
+        import kindex.extract as extract_mod
+        from kindex.hooks import capture_session_end
+        from kindex.sessions import get_tag, start_tag
+
+        monkeypatch.chdir(tmp_path)
+        start_tag(store, "capture-tag", project_path=str(tmp_path))
+        monkeypatch.setattr(
+            extract_mod,
+            "extract",
+            lambda *_args, **_kwargs: {
+                "concepts": [{
+                    "title": "Captured concept",
+                    "content": "Enough detail to retain this concept.",
+                    "domains": [],
+                    "type": "concept",
+                }],
+                "decisions": [],
+                "questions": [],
+                "connections": [],
+                "bridge_opportunities": [],
+            },
+        )
+
+        capture_session_end(
+            store,
+            config,
+            ledger,
+            session_text="A sufficiently long session transcript for extraction.",
+        )
+
+        tag = get_tag(store, "capture-tag", project_path=str(tmp_path))
+        assert len(tag["extra"]["linked_nodes"]) == 1
+        captured_id = tag["extra"]["linked_nodes"][0]
+        assert any(
+            edge["to_id"] == tag["id"]
+            for edge in store.edges_from(captured_id)
+        )
+
 
 class TestWriteInboxItem:
     def test_write_inbox_item(self, config):

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -1,5 +1,7 @@
 """Tests for session tag management: start, update, segment, pause, resume, complete."""
 
+import json
+import sqlite3
 import subprocess
 import sys
 
@@ -57,13 +59,25 @@ class TestStartTag:
             start_tag(store, "test-tag")
 
     def test_start_allows_reuse_of_completed_name(self, store):
-        from kindex.sessions import start_tag, complete_tag
+        from kindex.sessions import complete_tag, get_tag, start_tag, update_tag
 
-        start_tag(store, "reusable")
+        first = start_tag(store, "reusable", focus="old")
         complete_tag(store, "reusable")
-        # Should not raise
-        nid = start_tag(store, "reusable")
-        assert nid
+        second = start_tag(store, "reusable", focus="new")
+        update_tag(store, "reusable", focus="current")
+
+        assert get_tag(store, "reusable")["id"] == second
+        assert store.get_node(first)["extra"]["current_focus"] == "old"
+        assert store.get_node(second)["extra"]["current_focus"] == "current"
+
+    def test_same_name_is_scoped_to_project(self, store):
+        from kindex.sessions import get_tag, start_tag
+
+        first = start_tag(store, "shared", project_path="/project/a")
+        second = start_tag(store, "shared", project_path="/project/b")
+
+        assert get_tag(store, "shared", project_path="/project/a")["id"] == first
+        assert get_tag(store, "shared", project_path="/project/b")["id"] == second
 
     def test_start_empty_name_raises(self, store):
         from kindex.sessions import start_tag
@@ -224,6 +238,30 @@ class TestPauseAndComplete:
         with pytest.raises(ValueError, match="not found"):
             complete_tag(store, "nonexistent")
 
+    def test_resume_reactivates_paused_tag(self, store):
+        from kindex.sessions import get_tag, pause_tag, resume_tag, start_tag
+
+        start_tag(store, "resume-state", project_path="/project")
+        pause_tag(store, "resume-state", project_path="/project")
+
+        resumed = resume_tag(store, "resume-state", project_path="/project")
+
+        assert resumed["extra"]["session_status"] == "active"
+        assert resumed["extra"]["paused_at"] is None
+        assert resumed["extra"]["paused_reason"] is None
+        assert get_tag(
+            store, "resume-state", project_path="/project"
+        )["extra"]["session_status"] == "active"
+
+    def test_completed_tag_cannot_be_resumed(self, store):
+        from kindex.sessions import complete_tag, resume_tag, start_tag
+
+        start_tag(store, "finished", project_path="/project")
+        complete_tag(store, "finished", project_path="/project")
+
+        with pytest.raises(ValueError, match="completed"):
+            resume_tag(store, "finished", project_path="/project")
+
 
 class TestGetTag:
     def test_get_by_name(self, store):
@@ -286,6 +324,23 @@ class TestListTags:
         tags = list_tags(store, project_path="/proj/a")
         assert len(tags) == 1
         assert tags[0]["extra"]["tag"] == "proj-a"
+
+    def test_status_filter_is_applied_before_limit(self, store):
+        from kindex.sessions import complete_tag, list_tags, start_tag
+
+        active_id = start_tag(store, "older-active")
+        store.conn.execute(
+            "UPDATE nodes SET updated_at = '2020-01-01T00:00:00' WHERE id = ?",
+            (active_id,),
+        )
+        for index in range(3):
+            name = f"newer-completed-{index}"
+            start_tag(store, name)
+            complete_tag(store, name)
+
+        active = list_tags(store, status="active", limit=1)
+
+        assert [tag["id"] for tag in active] == [active_id]
 
 
 class TestResumeContext:
@@ -399,10 +454,13 @@ class TestTagCLI:
         d = str(tmp_path)
         run("tag", "start", "resume-cli", "--focus", "Resuming",
             "--description", "Resume test", data_dir=d)
+        run("tag", "pause", "resume-cli", data_dir=d)
         r = run("tag", "resume", "resume-cli", data_dir=d)
         assert r.returncode == 0
         assert "resume-cli" in r.stdout
         assert "Resuming" in r.stdout
+        shown = run("tag", "show", "resume-cli", data_dir=d)
+        assert "Status: active" in shown.stdout
 
     def test_tag_pause(self, tmp_path):
         d = str(tmp_path)
@@ -468,3 +526,108 @@ class TestStoreSessionMethods:
     def test_get_session_tag_by_name_not_found(self, store):
         tag = store.get_session_tag_by_name("nonexistent")
         assert tag is None
+
+    def test_active_name_and_project_are_unique_in_storage(self, store):
+        extra = {
+            "tag": "unique",
+            "project_path": "/project",
+            "session_status": "active",
+        }
+        first = store.add_node("unique", node_type="session", extra=extra)
+
+        with pytest.raises(sqlite3.IntegrityError):
+            store.add_node("unique", node_type="session", extra=extra)
+
+        rows = store.get_session_tags(status="active", project_path="/project")
+        assert [row["id"] for row in rows] == [first]
+
+
+def test_session_uniqueness_migration_pauses_older_duplicates(tmp_path):
+    cfg = Config(data_dir=str(tmp_path))
+    store = Store(cfg)
+    _ = store.conn
+    store.conn.execute("DROP INDEX idx_session_active_tag_project")
+    store.conn.execute("DROP INDEX idx_suggestions_pair")
+    store.conn.execute("UPDATE meta SET value = '11' WHERE key = 'schema_version'")
+    extra = {
+        "tag": "duplicate",
+        "project_path": "/project",
+        "session_status": "active",
+    }
+    first = store.add_node("duplicate", node_type="session", extra=extra)
+    second = store.add_node("duplicate", node_type="session", extra=extra)
+    store.conn.execute(
+        "UPDATE nodes SET updated_at = '2026-01-01T00:00:00' WHERE id = ?",
+        (first,),
+    )
+    store.conn.execute(
+        "UPDATE nodes SET updated_at = '2026-02-01T00:00:00' WHERE id = ?",
+        (second,),
+    )
+    store.conn.commit()
+    store.close()
+
+    migrated = Store(cfg)
+    rows = migrated.conn.execute(
+        "SELECT id, extra FROM nodes WHERE type = 'session' ORDER BY id"
+    ).fetchall()
+    extras = {row["id"]: json.loads(row["extra"]) for row in rows}
+    statuses = {node_id: extra["session_status"] for node_id, extra in extras.items()}
+
+    assert statuses == {first: "paused", second: "active"}
+    assert extras[first]["paused_reason"] == (
+        "duplicate-active-session-migration-v12"
+    )
+    assert migrated.get_meta("schema_version") == "12"
+    assert migrated.conn.execute(
+        """SELECT 1 FROM sqlite_master
+             WHERE type = 'index' AND name = 'idx_suggestions_pair'"""
+    ).fetchone()
+    with pytest.raises(sqlite3.IntegrityError):
+        migrated.add_node("duplicate", node_type="session", extra=extra)
+    migrated.close()
+
+
+def test_session_uniqueness_migration_has_total_tiebreak(tmp_path):
+    cfg = Config(data_dir=str(tmp_path))
+    store = Store(cfg)
+    _ = store.conn
+    store.conn.execute("DROP INDEX idx_session_active_tag_project")
+    store.conn.execute("UPDATE meta SET value = '11' WHERE key = 'schema_version'")
+    extra = {
+        "tag": "tie",
+        "project_path": "/project",
+        "session_status": "active",
+    }
+    for index in range(11):
+        store.add_node(
+            "tie",
+            node_id=f"duplicate-{index:02d}",
+            node_type="session",
+            extra=extra,
+        )
+    store.conn.execute(
+        """UPDATE nodes
+              SET updated_at = '2026-01-01T00:00:00',
+                  created_at = '2026-01-01T00:00:00'
+            WHERE type = 'session'"""
+    )
+    store.conn.commit()
+    store.close()
+
+    migrated = Store(cfg)
+    active = migrated.get_session_tags(
+        status="active", project_path="/project", limit=20
+    )
+    paused = migrated.get_session_tags(
+        status="paused", project_path="/project", limit=20
+    )
+
+    assert [row["id"] for row in active] == ["duplicate-10"]
+    assert len(paused) == 10
+    assert all(
+        row["extra"]["paused_reason"]
+        == "duplicate-active-session-migration-v12"
+        for row in paused
+    )
+    migrated.close()

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -53,6 +53,23 @@ class TestNodeOperations:
         assert node["title"] == "Updated"
         assert node["weight"] == 0.9
 
+    def test_same_id_upsert_preserves_relationships(self, store):
+        store.add_node("Original", node_id="same")
+        store.add_node("Peer", node_id="peer")
+        store.add_edge("same", "peer", provenance="test")
+        before_rowid = store.conn.execute(
+            "SELECT rowid FROM nodes WHERE id = 'same'"
+        ).fetchone()[0]
+
+        store.add_node("Updated", node_id="same")
+
+        assert store.get_node("same")["title"] == "Updated"
+        after_rowid = store.conn.execute(
+            "SELECT rowid FROM nodes WHERE id = 'same'"
+        ).fetchone()[0]
+        assert after_rowid == before_rowid
+        assert {edge["to_id"] for edge in store.edges_from("same")} == {"peer"}
+
     def test_delete_node(self, store):
         nid = store.add_node("Doomed")
         store.delete_node(nid)
@@ -185,3 +202,12 @@ class TestStats:
         s = store.stats()
         assert s["nodes"] == 2
         assert s["edges"] >= 1
+
+    def test_stats_use_same_explicit_node_vocabulary(self, store):
+        store.add_node("Knowledge", node_id="knowledge")
+        store.add_node("Session", node_id="session", node_type="session")
+
+        stats = store.stats()
+
+        assert stats["nodes"] == stats["semantic_nodes"] == 1
+        assert stats["stored_nodes"] == 2

--- a/tests/test_suggestions.py
+++ b/tests/test_suggestions.py
@@ -87,6 +87,7 @@ class TestAddAndListSuggestions:
 
         assert store.suggestion_exists("Alpha", "Beta") is False
         assert store.suggestion_exists("Alpha", "Beta", status="accepted") is True
+        assert store.suggestion_exists("Alpha", "Beta", status=None) is True
 
     def test_suggestions_have_dream_indexes(self, store):
         """Schema includes indexes needed by scheduled dream runs."""
@@ -95,6 +96,7 @@ class TestAddAndListSuggestions:
 
         assert "idx_suggestions_status_created" in names
         assert "idx_suggestions_status_pair" in names
+        assert "idx_suggestions_pair" in names
 
 
 class TestAcceptSuggestion:
@@ -142,6 +144,31 @@ class TestAcceptSuggestion:
         r = run("suggest", "--accept", str(sid), data_dir=d)
         assert r.returncode == 0
         assert "Accepted" in r.stdout or "created" in r.stdout.lower()
+
+    def test_accept_resolves_stable_node_ids_via_cli(self, tmp_path):
+        """Dream proposals use IDs so duplicate titles stay unambiguous."""
+        d = str(tmp_path)
+        run("init", data_dir=d)
+
+        cfg = Config(data_dir=d)
+        s = Store(cfg)
+        s.add_node("Alpha Concept", node_id="alpha", node_type="concept")
+        s.add_node("Beta Concept", node_id="beta", node_type="concept")
+        sid = s.add_suggestion(
+            concept_a="alpha",
+            concept_b="beta",
+            reason="shared domain",
+            source="dream-cycle-domain",
+        )
+        s.close()
+
+        result = run("suggest", "--accept", str(sid), data_dir=d)
+
+        assert result.returncode == 0
+        assert "Accepted" in result.stdout
+        reopened = Store(cfg)
+        assert reopened.edges_from("alpha", semantic_only=True)
+        reopened.close()
 
 
 class TestRejectSuggestion:


### PR DESCRIPTION
Closes #19.

## Summary

- Exclude session topology and legacy Dream domain-co-membership edges from semantic health metrics while retaining the physical rows for forensic and compatibility access.
- Add a real paused-session resume path, enforce one active session per exact tag and project, and reversibly archive only completed, unlinked session leaves.
- Replace Dream's domain clique writes with bounded, sparse review suggestions; preserve resolved pair history so rejected or accepted suggestions are not recreated.
- Deduplicate overlapping deep-Dream clusters, including overlap with prior summary nodes, and make candidate/proposal selection stable across weight decay.
- Report semantic and stored graph counts separately in CLI/MCP output.

## Migration and recovery

Schema v12 creates a partial unique active-session index and pauses older duplicate active rows using a total timestamp/ID ordering. It does not delete node or edge rows, and records `paused_reason=duplicate-active-session-migration-v12` on demoted sessions. The migration also adds an indexed Dream suggestion pair lookup.

I validated the migration on a production-size snapshot (28,987 nodes / 113,555 edges): node and edge row counts were identical before and after, five duplicate-active groups became zero, and exactly eleven older sessions were demoted. The original snapshot remains available for recovery.

## Verification

- `make check` — 1,987 passed
- focused session, archive, Dream, graph-metrics, CLI, and MCP regression suites — green
- production-size migration copy — row-preserving and duplicate-free
- deep-Dream dry run — deterministic and write-free
- bounded non-dry Dream run — pending cap held at 50 and legacy domain-edge count did not increase
- proposal stability after weight decay — symmetric difference 0
- `git diff --check` and pre-push policy — green
