### PR TITLE
TOOL-1160: preserve graph transfer lifecycle and provenance

### DIFF
--- a/docs/human-guide.md
+++ b/docs/human-guide.md
@@ -419,8 +419,11 @@ an identical snapshot adds no nodes, edges, audit rows or changed timestamps.
 Explicit IDs never fall back to matching titles; legacy title-only records require
 an unambiguous match. Forward edges work because all nodes are imported first.
 Exported edges are directed arcs; legacy edges without `bidirectional` retain the
-old bidirectional convention. For separately batched graphs, import every node
-before the edge-only pass; missing fields in that pass cannot clear content.
+old bidirectional convention. Explicit arcs take precedence over implied reverse
+arcs regardless of file order. Changed edge weights/provenance fail merge and are
+updated only in replace mode; omitted fields preserve existing evidence. Conflicting
+duplicate declarations in one file fail either mode. For separately batched graphs,
+import every node before the edge-only pass; missing fields in that pass cannot clear content.
 
 Default `--mode merge` fills missing information but refuses conflicting claims;
 it never concatenates two different statements. Inspect a conflict before using
@@ -438,6 +441,15 @@ canonical evidence URLs and digests. A redacted path is imported as unbound
 `extra.imported_referent`, not rebound to a misleading basename. The common
 credential redactor also runs on all exports/imports. Curate the content's audience
 before sharing: a label is not proof that arbitrary prose contains no private data.
+
+Validation uses `pytest tests/test_graph_transfer.py` for real CLI subprocesses,
+SQLite rollback/replay, three-hop JSON/JSONL transfers, cross-platform privacy and
+the installed `kin` console entry point. Run the same suite with the built wheel
+installed in a fresh environment to check the packaged artifact, not just an
+editable checkout; also run the full `pytest tests/` and `make test-isolation`.
+For full code-adapter coverage, install `.[dev,all]`, `tree-sitter`,
+`tree-sitter-python`, `tree-sitter-rust`, and Universal Ctags with JSON support
+(`ctags --list-features` must include `json`, not macOS's bundled BSD Ctags).
 
 ## Release Surface Checklist
 

--- a/docs/human-guide.md
+++ b/docs/human-guide.md
@@ -390,6 +390,55 @@ kin index
 kin export code-map --directory . --project-name kindex --output .kin/code-map.json
 ```
 
+### Transfer a graph snapshot
+
+```bash
+kin export --audience private --format jsonl > graph.jsonl
+kin import graph.jsonl --data-dir /path/to/isolated/graph --dry-run
+kin import graph.jsonl --data-dir /path/to/isolated/graph
+```
+
+JSON arrays, single JSON records and JSONL remain supported. These are knowledge
+snapshots, **not full backups** of tasks, locks, reminders, policy or runtime state.
+Only lifecycle keys from `extra` travel: expiry, stale-referent and supersession
+markers, plus imported verification/redacted-referent evidence. Other `extra`
+fields do not travel. Use the existing `kin repo-memory` candidate-review flow
+when importing automatically discovered Git evidence; this CLI does not replace it.
+
+Transfer preserves node IDs, status, audience, source provenance, timestamps,
+valid-time boundaries, referent bindings and edges. Missing clocks stay unknown;
+the importer does not stamp old evidence as newly observed. Claimed upstream
+verification is stored under `extra.imported_verification`, **never** installed
+as local `verified_at`, `verified_by` or `prov_method`. Even a claimed reviewer
+name is not authentication. Imported claims require local review before trusted
+recall, and memory content is not authorization to perform actions.
+
+An import is one SQLite transaction, including its audit rows. Invalid records,
+unresolved edges and conflicting nonempty fields fail the entire file. Replaying
+an identical snapshot adds no nodes, edges, audit rows or changed timestamps.
+Explicit IDs never fall back to matching titles; legacy title-only records require
+an unambiguous match. Forward edges work because all nodes are imported first.
+Exported edges are directed arcs; legacy edges without `bidirectional` retain the
+old bidirectional convention. For separately batched graphs, import every node
+before the edge-only pass; missing fields in that pass cannot clear content.
+
+Default `--mode merge` fills missing information but refuses conflicting claims;
+it never concatenates two different statements. Inspect a conflict before using
+`--mode replace`, which changes only supplied fields and revokes old local
+verification. Neither mode can widen an existing audience, reactivate inactive
+knowledge, relax validity/expiry or erase a stale/superseded marker. Resolve those
+through explicit local lifecycle/review operations, not an old snapshot. A
+`--dry-run` validates the same transaction and rolls back all graph changes.
+
+`--audience team` includes team/org/public; `org` includes org/public; `public`
+includes only public; `private` includes everything. Edges and supersession IDs
+cannot name excluded nodes. Org/public exports anonymize provenance/verification
+actors, omit private diagnostic prose and machine-local referent paths, and keep
+canonical evidence URLs and digests. A redacted path is imported as unbound
+`extra.imported_referent`, not rebound to a misleading basename. The common
+credential redactor also runs on all exports/imports. Curate the content's audience
+before sharing: a label is not proof that arbitrary prose contains no private data.
+
 ## Release Surface Checklist
 
 Before calling a release done, verify each public surface:

--- a/src/kindex/cli.py
+++ b/src/kindex/cli.py
@@ -1700,7 +1700,10 @@ def _strip_pii(node: dict) -> dict:
     from .privacy import redact
     node = redact(node)
     node["prov_who"] = ["anonymous"]
-    node["prov_source"] = Path(node.get("prov_source", "")).name if node.get("prov_source") else ""
+    from urllib.parse import urlsplit
+    source = node.get("prov_source", "")
+    if urlsplit(source).scheme not in ("http", "https"):
+        node["prov_source"] = Path(source).name
     # Strip emails from content
     content = node.get("content", "")
     content = re.sub(r'\S+@\S+\.\S+', '[email]', content)
@@ -1768,29 +1771,10 @@ def cmd_export(args):
               file=sys.stderr)
         sys.exit(1)
 
-    if target_audience == "private":
-        nodes = store.all_nodes(limit=10000)
-    elif target_audience == "team":
-        team = store.all_nodes(audience="team", limit=10000)
-        org = store.all_nodes(audience="org", limit=10000)
-        public = store.all_nodes(audience="public", limit=10000)
-        seen = set()
-        nodes = []
-        for n in team + org + public:
-            if n["id"] not in seen:
-                seen.add(n["id"])
-                nodes.append(n)
-    elif target_audience == "org":
-        org = store.all_nodes(audience="org", limit=10000)
-        public = store.all_nodes(audience="public", limit=10000)
-        seen = set()
-        nodes = []
-        for n in org + public:
-            if n["id"] not in seen:
-                seen.add(n["id"])
-                nodes.append(n)
-    else:  # public
-        nodes = store.all_nodes(audience="public", limit=10000)
+    audiences = {"private": (None,), "team": ("team", "org", "public"),
+                 "org": ("org", "public"), "public": ("public",)}[target_audience]
+    # A snapshot must not silently truncate at the query helper's display limit.
+    nodes = [n for audience in audiences for n in store.all_nodes(audience=audience, limit=-1)]
 
     # Apply PII stripping for public/org exports
     strip_pii = target_audience in ("public", "org")
@@ -1798,29 +1782,11 @@ def cmd_export(args):
     # Strip edges that cross audience boundaries
     output = []
     node_ids = {n["id"] for n in nodes}
+    from .graph_transfer import export_record
     for n in nodes:
         if strip_pii:
             n = _strip_pii(n)
-        edges = store.edges_from(n["id"])
-        # Only keep edges where target is in our exported set
-        filtered_edges = [e for e in edges if e["to_id"] in node_ids]
-
-        record = {
-            "id": n["id"], "type": n["type"], "title": n["title"],
-            "content": n.get("content", ""),
-            "weight": n["weight"], "domains": n.get("domains", []),
-            "audience": n.get("audience", "private"),
-            "edges": [{"to": e["to_id"], "type": e["type"], "weight": e["weight"]}
-                      for e in filtered_edges],
-        }
-        # R0 referent binding + clocks round-trip through export/import.
-        if isinstance(n.get("referent"), dict):
-            record["referent"] = n["referent"]
-        for clock in ("asserted_at", "true_of"):
-            if n.get(clock):
-                record[clock] = n[clock]
-        from .privacy import redact
-        output.append(redact(record))
+        output.append(export_record(n, store.edges_from(n["id"]), node_ids, public=strip_pii))
 
     if args.format == "jsonl":
         for item in output:
@@ -3727,122 +3693,28 @@ def cmd_skills(args):
 
 def cmd_import_graph(args):
     """Import nodes and edges from a JSON or JSONL file."""
+    from .graph_transfer import import_records
+
     store = _store(args)
-    filepath = Path(args.filepath)
-
-    if not filepath.exists():
-        print(f"Error: '{filepath}' not found.", file=sys.stderr)
-        sys.exit(1)
-
-    text = filepath.read_text()
-    if filepath.suffix == ".jsonl" or args.format == "jsonl":
-        items = [json.loads(line) for line in text.strip().split("\n") if line.strip()]
-    else:
-        data = json.loads(text)
-        items = data if isinstance(data, list) else [data]
-
     dry_run = getattr(args, "dry_run", False)
-    merge = getattr(args, "mode", "merge") == "merge"
-    created = updated = edges_created = skipped = 0
-
-    for item in items:
-        title = item.get("title", "")
-        node_id = item.get("id", "")
-
-        if not title and not node_id:
-            skipped += 1
-            continue
-
-        existing = None
-        if node_id:
-            existing = store.get_node(node_id)
-        if not existing and title:
-            existing = store.get_node_by_title(title)
-
-        if existing:
-            if merge:
-                # Merge: update content if new content is provided
-                new_content = item.get("content", "")
-                old_content = existing.get("content", "")
-                if new_content and new_content != old_content:
-                    if not dry_run:
-                        combined = old_content + "\n\n" + new_content if old_content else new_content
-                        store.update_node(existing["id"], content=combined)
-                    updated += 1
-                    if dry_run:
-                        print(f"  Would update: {title}")
-                else:
-                    skipped += 1
-            else:
-                # Replace
-                if not dry_run:
-                    store.update_node(existing["id"],
-                                      title=title,
-                                      content=item.get("content", ""),
-                                      weight=item.get("weight", existing["weight"]))
-                updated += 1
-                if dry_run:
-                    print(f"  Would replace: {title}")
+    try:
+        filepath = Path(args.filepath)
+        text = filepath.read_text()
+        if filepath.suffix == ".jsonl" or args.format == "jsonl":
+            items = [json.loads(line) for line in text.splitlines() if line.strip()]
         else:
-            if not dry_run:
-                # R0 binding travels with the import; a malformed binding is
-                # reported visibly and the node is created unbound rather
-                # than silently dropped or silently bound wrong.
-                binding: dict = {}
-                if any(item.get(k) for k in ("referent", "asserted_at", "true_of")):
-                    try:
-                        from .store import _normalize_binding
-                        _normalize_binding(
-                            item.get("referent"),
-                            item.get("asserted_at"),
-                            item.get("true_of"),
-                        )
-                        binding = {
-                            "referent": item.get("referent"),
-                            "asserted_at": item.get("asserted_at"),
-                            "true_of": item.get("true_of"),
-                        }
-                    except (ValueError, TypeError) as exc:
-                        print(f"  Warning: invalid referent binding on "
-                              f"'{title}' ({exc}); imported unbound",
-                              file=sys.stderr)
-                store.add_node(
-                    title=title,
-                    content=item.get("content", ""),
-                    node_id=node_id or None,
-                    node_type=item.get("type", "concept"),
-                    domains=item.get("domains", []),
-                    weight=item.get("weight", 0.5),
-                    audience=item.get("audience", "private"),
-                    prov_activity="import",
-                    prov_source=str(filepath),
-                    **binding,
-                )
-            created += 1
-            if dry_run:
-                print(f"  Would create: {title}")
-
-        # Process edges
-        for edge in item.get("edges", []):
-            to_id = edge.get("to", "")
-            if not to_id:
-                continue
-            from_id = node_id or (existing["id"] if existing else "")
-            if not from_id:
-                continue
-            # Check if target exists
-            target = store.get_node(to_id) or store.get_node_by_title(to_id)
-            if target and not dry_run:
-                store.add_edge(from_id, target["id"],
-                               edge_type=edge.get("type", "relates_to"),
-                               weight=edge.get("weight", 0.5),
-                               provenance="import")
-                edges_created += 1
-
+            data = json.loads(text)
+            items = data if isinstance(data, list) else [data]
+        counts = import_records(store, items, replace=getattr(args, "mode", "merge") == "replace",
+                                dry_run=dry_run)
+    except (OSError, ValueError, TypeError) as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        raise SystemExit(1) from None
+    finally:
+        store.close()
     prefix = "[DRY RUN] " if dry_run else ""
-    print(f"{prefix}Import complete: {created} created, {updated} updated, "
-          f"{edges_created} edges, {skipped} skipped")
-    store.close()
+    print(f"{prefix}Import complete: {counts['created']} created, {counts['updated']} updated, "
+          f"{counts['edges']} edges, {counts['skipped']} skipped")
 
 
 # ── cron ──────────────────────────────────────────────────────────────

--- a/src/kindex/cli.py
+++ b/src/kindex/cli.py
@@ -1700,10 +1700,11 @@ def _strip_pii(node: dict) -> dict:
     from .privacy import redact
     node = redact(node)
     node["prov_who"] = ["anonymous"]
+    from pathlib import PureWindowsPath
     from urllib.parse import urlsplit
     source = node.get("prov_source", "")
     if urlsplit(source).scheme not in ("http", "https"):
-        node["prov_source"] = Path(source).name
+        node["prov_source"] = PureWindowsPath(source).name
     # Strip emails from content
     content = node.get("content", "")
     content = re.sub(r'\S+@\S+\.\S+', '[email]', content)

--- a/src/kindex/graph_transfer.py
+++ b/src/kindex/graph_transfer.py
@@ -1,0 +1,275 @@
+"""Graph snapshots are evidence, not locally verified assertions or runtime state."""
+
+from __future__ import annotations
+
+import json
+import math
+from pathlib import Path
+from urllib.parse import urlsplit
+
+from .privacy import redact
+from .schema import AUDIENCES
+from .store import _jdumps, _normalize_binding, _now, _uuid, _validate_expires
+from .trust import parse_rfc3339, validate_interval
+
+TEXT_FIELDS = (
+    "type", "title", "content", "intent", "status", "audience", "prov_when",
+    "prov_activity", "prov_why", "prov_source", "created_at", "updated_at",
+)
+LIST_FIELDS = ("aka", "domains", "prov_who")
+CLOCK_FIELDS = ("valid_at", "invalid_at", "asserted_at", "true_of")
+VERIFICATION_FIELDS = ("verified_at", "verified_by", "prov_method")
+# Deliberately exclude locks, actors, tasks, reminders and executable actions.
+LIFECYCLE_KEYS = (
+    "expires", "expired_at", "referent_stale", "superseded_by", "supersedes",
+    "supersede_reason", "imported_verification", "imported_referent",
+)
+
+
+def export_record(node: dict, edges: list[dict], visible_ids: set[str], *, public: bool) -> dict:
+    record = {key: node[key] for key in (*TEXT_FIELDS, *LIST_FIELDS, *CLOCK_FIELDS,
+                                       *VERIFICATION_FIELDS, "id", "weight", "referent") if key in node}
+    for key in LIST_FIELDS:
+        record[key] = node.get(key) or []  # Older SQLite defaults used empty text.
+    record["extra"] = {k: v for k, v in (node.get("extra") or {}).items() if k in LIFECYCLE_KEYS}
+    # These IDs are relationships too: never expose a hidden endpoint.
+    for key in ("supersedes", "superseded_by"):
+        if record["extra"].get(key) not in visible_ids:
+            record["extra"].pop(key, None)
+    record["edges"] = [
+        {"to": e["to_id"], "type": e["type"], "weight": e["weight"],
+         "bidirectional": False, "provenance": "" if public else e.get("provenance", "")}
+        for e in edges if e["to_id"] in visible_ids
+    ]
+    if public:
+        record["prov_who"] = ["anonymous"]
+        record["verified_by"] = "anonymous" if record.get("verified_by") else None
+        # Preserve canonical evidence URLs, not machine-local paths or actor prose.
+        source = record.get("prov_source", "")
+        if urlsplit(source).scheme not in ("http", "https"):
+            record["prov_source"] = Path(source).name
+        for key in ("intent", "prov_why", "prov_activity"):
+            record.pop(key, None)
+        record["extra"].pop("supersede_reason", None)
+        verification = record["extra"].get("imported_verification")
+        if isinstance(verification, dict):
+            record["extra"]["imported_verification"] = {
+                "verified_at": verification.get("verified_at"), "verified_by": "anonymous",
+            }
+        # Methods and stale diagnostics may contain private actor/path prose.
+        record.pop("prov_method", None)
+        if record["extra"].get("referent_stale"):
+            record["extra"]["referent_stale"] = {"reason": "upstream-stale"}
+        for container, key in ((record, "referent"), (record["extra"], "imported_referent")):
+            binding = container.get(key)
+            if isinstance(binding, dict):
+                binding = {k: v for k, v in binding.items() if k in
+                           ("path", "url", "content_digest", "digest_scope", "path_redacted", "url_redacted")}
+                container[key] = binding
+            if isinstance(binding, dict) and Path(binding.get("path", "")).is_absolute():
+                binding = dict(binding)
+                binding.pop("path")
+                binding["path_redacted"] = True
+                container[key] = binding
+    return redact(record)
+
+
+def _fields(item: dict) -> dict:
+    if not isinstance(item, dict):
+        raise ValueError("Each graph record must be an object")
+    if "id" in item and (not isinstance(item["id"], str) or not item["id"].strip()):
+        raise ValueError("Graph IDs must be nonempty strings")
+    if "id" in item and redact(item["id"]) != item["id"]:
+        raise ValueError("Graph ID contains credentials")
+    fields = {k: item[k] for k in (*TEXT_FIELDS, *LIST_FIELDS, *CLOCK_FIELDS, "weight", "referent") if k in item}
+    for key in TEXT_FIELDS:
+        if key in fields and not isinstance(fields[key], str):
+            raise ValueError(f"{key} must be text")
+    for key in LIST_FIELDS:
+        if key in fields and (not isinstance(fields[key], list) or
+                              not all(isinstance(v, str) for v in fields[key])):
+            raise ValueError(f"{key} must be a list of strings")
+    if "audience" in fields and fields["audience"] not in AUDIENCES:
+        raise ValueError("Unknown audience")
+    if "status" in fields and not fields["status"].strip():
+        raise ValueError("Status must not be empty")
+    if "weight" in fields:
+        _weight(fields["weight"])
+    extra = item.get("extra", {})
+    if not isinstance(extra, dict):
+        raise ValueError("extra must be an object")
+    extra = {k: v for k, v in extra.items() if k in LIFECYCLE_KEYS}
+    if "expires" in extra:
+        _validate_expires(extra["expires"])
+    for key in ("expired_at", "supersedes", "superseded_by", "supersede_reason"):
+        if key in extra and not isinstance(extra[key], str):
+            raise ValueError(f"{key} must be text")
+    for key in ("referent_stale", "imported_verification", "imported_referent"):
+        if key in extra and not isinstance(extra[key], dict):
+            raise ValueError(f"{key} must be an object")
+    if "imported_verification" in extra:
+        verification = extra["imported_verification"]
+        if any(v is not None and not isinstance(v, str) for k, v in verification.items() if k in VERIFICATION_FIELDS):
+            raise ValueError("Claimed verification must be text")
+        extra["imported_verification"] = {k: v for k, v in verification.items() if k in VERIFICATION_FIELDS}
+    claimed = {k: item[k] for k in VERIFICATION_FIELDS if item.get(k) is not None}
+    if claimed:
+        if not all(isinstance(v, str) for v in claimed.values()):
+            raise ValueError("Claimed verification must be text")
+        extra["imported_verification"] = claimed
+    # A deliberately redacted location is evidence, never a fabricated binding.
+    binding = fields.get("referent")
+    if isinstance(binding, dict) and (binding.get("path_redacted") or binding.get("url_redacted")):
+        extra["imported_referent"] = binding
+        fields["referent"] = None
+    if any(k in fields for k in ("referent", "asserted_at", "true_of")):
+        binding, asserted, observed = _normalize_binding(
+            fields.get("referent"), fields.get("asserted_at"), fields.get("true_of"))
+        if "referent" in fields:
+            fields["referent"] = json.loads(binding) if binding else None
+        # Never invent freshness clocks for legacy evidence lacking them.
+        if "asserted_at" in fields:
+            fields["asserted_at"] = asserted
+        if "true_of" in fields:
+            fields["true_of"] = observed
+    for key in ("valid_at", "invalid_at"):
+        if key in fields:
+            fields[key] = validate_interval(fields[key], None)[0]
+    if extra:
+        fields["extra"] = extra
+    return redact(fields)
+
+
+def _weight(value) -> None:
+    if isinstance(value, bool) or not isinstance(value, (int, float)) or not math.isfinite(value):
+        raise ValueError("Weight must be a finite number")
+
+
+def _resolve(store, reference: str, *, by_title: bool = False) -> dict | None:
+    column = "title COLLATE NOCASE" if by_title else "id"
+    rows = store.conn.execute(f"SELECT * FROM nodes WHERE {column} = ?", (reference,)).fetchall()
+    if len(rows) > 1:
+        raise ValueError("Ambiguous legacy title; use an explicit ID")
+    return store._row_to_dict(rows[0]) if rows else None
+
+
+def _protect(existing: dict, fields: dict) -> None:
+    if existing["status"] != "active" and fields.get("status") == "active":
+        raise ValueError("Import cannot reactivate inactive knowledge")
+    if AUDIENCES.index(fields.get("audience", existing["audience"])) > AUDIENCES.index(existing["audience"]):
+        raise ValueError("Import cannot widen an existing audience")
+    for key in ("invalid_at", "valid_at"):
+        old, new = existing.get(key), fields.get(key, existing.get(key))
+        if old:
+            if not new:
+                raise ValueError("Import cannot relax an existing valid-time boundary")
+            before, after = parse_rfc3339(old, field=key), parse_rfc3339(new, field=key)
+            relaxes = after > before if key == "invalid_at" else after < before
+            if relaxes:
+                raise ValueError("Import cannot relax an existing valid-time boundary")
+    extra = existing.get("extra") or {}
+    for key, value in fields.get("extra", {}).items():
+        if extra.get(key) and key in ("referent_stale", "expired_at", "superseded_by") and value != extra[key]:
+            raise ValueError("Import cannot remove or replace an existing lifecycle demotion")
+        if key == "expires" and extra.get(key) and value > extra[key]:
+            raise ValueError("Import cannot extend an existing expiry")
+
+
+def import_records(store, items: list[dict], *, replace: bool = False, dry_run: bool = False) -> dict:
+    """Atomic two-pass import. Missing fields are never destructive updates."""
+    if not isinstance(items, list):
+        raise ValueError("Graph must be an array of records")
+    if store.conn.in_transaction:
+        raise ValueError("Graph import requires its own transaction")
+    counts = dict(created=0, updated=0, edges=0, skipped=0)
+    bindings, changed = [], []
+    store.conn.execute("BEGIN IMMEDIATE")
+    try:
+        for item in items:
+            fields = _fields(item)
+            node_id = item.get("id")
+            title = fields.get("title", "")
+            if not node_id and not title.strip():
+                raise ValueError("Graph record requires an ID or title")
+            existing = _resolve(store, node_id) if node_id else _resolve(store, title, by_title=True)
+            node_id = existing["id"] if existing else node_id or _uuid()
+            bindings.append((node_id, item.get("edges", [])))
+            if existing:
+                _protect(existing, fields)
+                incoming_extra = fields.pop("extra", {})
+                old_extra = existing.get("extra") or {}
+                if not replace and any(k in old_extra and old_extra[k] != v for k, v in incoming_extra.items()):
+                    raise ValueError(f"Import conflict for {node_id}: lifecycle metadata")
+                if incoming_extra:
+                    fields["extra"] = {**old_extra, **incoming_extra}
+                fields = {k: v for k, v in fields.items() if v != existing.get(k)}
+                if not replace and any(existing.get(k) not in (None, "", [], {}) for k in fields):
+                    raise ValueError(f"Import conflict for {node_id}; inspect evidence before using --mode replace")
+                if not fields:
+                    counts["skipped"] += 1
+                    continue
+                store._check_lock(existing, actor=None, force=False, remedy="release the lock before importing")
+                # Even replacement cannot inherit the old claim's local verification.
+                fields.update({k: None for k in VERIFICATION_FIELDS})
+                fields.setdefault("updated_at", _now())
+                counts["updated"] += 1
+            else:
+                fields.setdefault("title", "")
+                fields.setdefault("prov_activity", "import")
+                for key in LIST_FIELDS:
+                    fields.setdefault(key, [])
+                counts["created"] += 1
+            validate_interval(fields.get("valid_at", (existing or {}).get("valid_at")),
+                              fields.get("invalid_at", (existing or {}).get("invalid_at")))
+            values = {k: _jdumps(v) if k in (*LIST_FIELDS, "extra", "referent") and v is not None else v
+                      for k, v in fields.items()}
+            if existing:
+                store.conn.execute(f"UPDATE nodes SET {', '.join(k + ' = ?' for k in values)} WHERE id = ?",
+                                   (*values.values(), node_id))
+            else:
+                store.conn.execute(f"INSERT INTO nodes (id, {', '.join(values)}) VALUES (?, {', '.join('?' for _ in values)})",
+                                   (node_id, *values.values()))
+            store._log_in_transaction(store.conn, "import_node", node_id, fields.get("title", ""))
+            changed.append(node_id)
+
+        # All endpoints now exist, regardless of input ordering.
+        for from_id, edges in bindings:
+            if not isinstance(edges, list):
+                raise ValueError("edges must be a list")
+            for edge in edges:
+                if not isinstance(edge, dict) or not isinstance(edge.get("to"), str) or not edge["to"]:
+                    raise ValueError("Edge requires a target ID or unambiguous legacy title")
+                target = _resolve(store, edge["to"]) or _resolve(store, edge["to"], by_title=True)
+                if not target:
+                    raise ValueError("Unresolved edge target; import all nodes before importing edges")
+                weight = edge.get("weight", 0.5)
+                _weight(weight)
+                kind, provenance = edge.get("type", "relates_to"), edge.get("provenance", "import")
+                if not isinstance(kind, str) or not kind or not isinstance(provenance, str):
+                    raise ValueError("Edge type and provenance must be text")
+                bidirectional = edge.get("bidirectional", True)
+                if not isinstance(bidirectional, bool):
+                    raise ValueError("bidirectional must be boolean")
+                arcs = [(from_id, target["id"], weight)]
+                if bidirectional:
+                    arcs.append((target["id"], from_id, weight * 0.8))
+                for source, dest, arc_weight in arcs:
+                    cursor = store.conn.execute(
+                        "INSERT INTO edges (from_id, to_id, type, weight, provenance) VALUES (?, ?, ?, ?, ?) "
+                        "ON CONFLICT(from_id, to_id, type) DO NOTHING",
+                        (source, dest, redact(kind), arc_weight, redact(provenance)))
+                    counts["edges"] += cursor.rowcount
+        if counts["edges"]:
+            store._log_in_transaction(store.conn, "import_edges", details={"count": counts["edges"]})
+        if not dry_run:
+            from .vectors import enqueue_embedding
+            for node_id in changed:
+                enqueue_embedding(store, node_id, commit=False)
+        if dry_run:
+            store.conn.rollback()
+        else:
+            store.conn.commit()
+    except BaseException:
+        store.conn.rollback()
+        raise
+    return counts

--- a/src/kindex/graph_transfer.py
+++ b/src/kindex/graph_transfer.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 import math
-from pathlib import Path
+from pathlib import PureWindowsPath
 from urllib.parse import urlsplit
 
 from .privacy import redact
@@ -47,7 +47,7 @@ def export_record(node: dict, edges: list[dict], visible_ids: set[str], *, publi
         # Preserve canonical evidence URLs, not machine-local paths or actor prose.
         source = record.get("prov_source", "")
         if urlsplit(source).scheme not in ("http", "https"):
-            record["prov_source"] = Path(source).name
+            record["prov_source"] = PureWindowsPath(source).name
         for key in ("intent", "prov_why", "prov_activity"):
             record.pop(key, None)
         record["extra"].pop("supersede_reason", None)
@@ -66,7 +66,7 @@ def export_record(node: dict, edges: list[dict], visible_ids: set[str], *, publi
                 binding = {k: v for k, v in binding.items() if k in
                            ("path", "url", "content_digest", "digest_scope", "path_redacted", "url_redacted")}
                 container[key] = binding
-            if isinstance(binding, dict) and Path(binding.get("path", "")).is_absolute():
+            if isinstance(binding, dict) and PureWindowsPath(binding.get("path", "")).anchor:
                 binding = dict(binding)
                 binding.pop("path")
                 binding["path_redacted"] = True
@@ -128,9 +128,9 @@ def _fields(item: dict) -> dict:
         if "referent" in fields:
             fields["referent"] = json.loads(binding) if binding else None
         # Never invent freshness clocks for legacy evidence lacking them.
-        if "asserted_at" in fields:
+        if fields.get("asserted_at") is not None:
             fields["asserted_at"] = asserted
-        if "true_of" in fields:
+        if fields.get("true_of") is not None:
             fields["true_of"] = observed
     for key in ("valid_at", "invalid_at"):
         if key in fields:
@@ -203,7 +203,7 @@ def import_records(store, items: list[dict], *, replace: bool = False, dry_run: 
                 if incoming_extra:
                     fields["extra"] = {**old_extra, **incoming_extra}
                 fields = {k: v for k, v in fields.items() if v != existing.get(k)}
-                if not replace and any(existing.get(k) not in (None, "", [], {}) for k in fields):
+                if not replace and any(existing.get(k) not in (None, "", [], {}) for k in fields if k != "extra"):
                     raise ValueError(f"Import conflict for {node_id}; inspect evidence before using --mode replace")
                 if not fields:
                     counts["skipped"] += 1
@@ -232,33 +232,7 @@ def import_records(store, items: list[dict], *, replace: bool = False, dry_run: 
             store._log_in_transaction(store.conn, "import_node", node_id, fields.get("title", ""))
             changed.append(node_id)
 
-        # All endpoints now exist, regardless of input ordering.
-        for from_id, edges in bindings:
-            if not isinstance(edges, list):
-                raise ValueError("edges must be a list")
-            for edge in edges:
-                if not isinstance(edge, dict) or not isinstance(edge.get("to"), str) or not edge["to"]:
-                    raise ValueError("Edge requires a target ID or unambiguous legacy title")
-                target = _resolve(store, edge["to"]) or _resolve(store, edge["to"], by_title=True)
-                if not target:
-                    raise ValueError("Unresolved edge target; import all nodes before importing edges")
-                weight = edge.get("weight", 0.5)
-                _weight(weight)
-                kind, provenance = edge.get("type", "relates_to"), edge.get("provenance", "import")
-                if not isinstance(kind, str) or not kind or not isinstance(provenance, str):
-                    raise ValueError("Edge type and provenance must be text")
-                bidirectional = edge.get("bidirectional", True)
-                if not isinstance(bidirectional, bool):
-                    raise ValueError("bidirectional must be boolean")
-                arcs = [(from_id, target["id"], weight)]
-                if bidirectional:
-                    arcs.append((target["id"], from_id, weight * 0.8))
-                for source, dest, arc_weight in arcs:
-                    cursor = store.conn.execute(
-                        "INSERT INTO edges (from_id, to_id, type, weight, provenance) VALUES (?, ?, ?, ?, ?) "
-                        "ON CONFLICT(from_id, to_id, type) DO NOTHING",
-                        (source, dest, redact(kind), arc_weight, redact(provenance)))
-                    counts["edges"] += cursor.rowcount
+        counts["edges"] = _import_edges(store, bindings, replace=replace)
         if counts["edges"]:
             store._log_in_transaction(store.conn, "import_edges", details={"count": counts["edges"]})
         if not dry_run:
@@ -273,3 +247,63 @@ def import_records(store, items: list[dict], *, replace: bool = False, dry_run: 
         store.conn.rollback()
         raise
     return counts
+
+
+def _import_edges(store, bindings, *, replace: bool) -> int:
+    """Import declared arcs before legacy implicit reverse arcs, in the caller's transaction."""
+    declared, reverse = {}, set()
+    for from_id, edges in bindings:
+        if not isinstance(edges, list):
+            raise ValueError("edges must be a list")
+        for edge in edges:
+            if not isinstance(edge, dict) or not isinstance(edge.get("to"), str) or not edge["to"]:
+                raise ValueError("Edge requires a target ID or unambiguous legacy title")
+            target = _resolve(store, edge["to"]) or _resolve(store, edge["to"], by_title=True)
+            if not target:
+                raise ValueError("Unresolved edge target; import all nodes before importing edges")
+            _weight(edge.get("weight", 0.5))
+            kind, provenance = edge.get("type", "relates_to"), edge.get("provenance", "import")
+            if not isinstance(kind, str) or not kind or not isinstance(provenance, str):
+                raise ValueError("Edge type and provenance must be text")
+            bidirectional = edge.get("bidirectional", True)
+            if not isinstance(bidirectional, bool):
+                raise ValueError("bidirectional must be boolean")
+            key = (from_id, target["id"], redact(kind))
+            fields = redact({k: edge[k] for k in ("weight", "provenance") if k in edge})
+            previous = declared.setdefault(key, {})
+            if any(k in previous and previous[k] != v for k, v in fields.items()):
+                raise ValueError("Import conflict: duplicate edge declarations disagree")
+            previous.update(fields)
+            if bidirectional:
+                reverse.add(key)
+
+    count = 0
+    for key, fields in declared.items():
+        existing = store.conn.execute(
+            "SELECT weight, provenance FROM edges WHERE from_id = ? AND to_id = ? AND type = ?", key,
+        ).fetchone()
+        values = {"weight": 0.5, "provenance": "import", **(dict(existing) if existing else {}), **fields}
+        declared[key] = values
+        if existing and dict(existing) == values:
+            continue
+        if existing and not replace:
+            raise ValueError(f"Import conflict for edge {key}; inspect evidence before using --mode replace")
+        store.conn.execute(
+            "INSERT INTO edges (from_id, to_id, type, weight, provenance, updated_at) VALUES (?, ?, ?, ?, ?, ?) "
+            "ON CONFLICT(from_id, to_id, type) DO UPDATE SET "
+            "weight = excluded.weight, provenance = excluded.provenance, updated_at = excluded.updated_at",
+            (*key, values["weight"], values["provenance"], _now()),
+        )
+        count += 1
+
+    # An implied reverse is a legacy convenience, not a replacement for an
+    # explicitly recorded arc. Deferring it also makes old two-way exports order-independent.
+    for key in sorted(reverse):
+        source, target, kind = key
+        values = declared[key]
+        count += store.conn.execute(
+            "INSERT INTO edges (from_id, to_id, type, weight, provenance, updated_at) VALUES (?, ?, ?, ?, ?, ?) "
+            "ON CONFLICT(from_id, to_id, type) DO NOTHING",
+            (target, source, kind, values["weight"] * 0.8, values["provenance"], _now()),
+        ).rowcount
+    return count

--- a/tests/test_batch0_capture.py
+++ b/tests/test_batch0_capture.py
@@ -323,7 +323,7 @@ def test_r1_2_fresh_install_stop_entry_has_no_text_and_is_idempotent(tmp_path):
 
 
 @pytest.mark.red_now
-def test_r1_2_rerun_migrates_old_broken_entry_preserving_siblings(tmp_path):
+def test_r1_2_rerun_migrates_old_broken_entry_preserving_siblings(tmp_path, monkeypatch):
     """spec@1f0cdd71 R1.2 (re-run-is-the-migration, issue-#15 pattern);
     strat@e58068c2 oracle row R1.2 (red_now).
 
@@ -339,6 +339,9 @@ def test_r1_2_rerun_migrates_old_broken_entry_preserving_siblings(tmp_path):
     """
     from kindex.setup import install_claude_hooks
 
+    # The released fixture names this binary. Exact handler ownership must
+    # be tested against that installation, not the test runner's venv path.
+    monkeypatch.setattr("kindex.setup._find_kin_path", lambda: "/opt/homebrew/bin/kin")
     old_stop = json.loads(_OLD_STOP_ENTRY_JSON)
     cfg, settings = _claude_cfg(
         tmp_path, seed_settings={"hooks": {"Stop": old_stop}})

--- a/tests/test_graph_transfer.py
+++ b/tests/test_graph_transfer.py
@@ -1,0 +1,284 @@
+"""Exercise the CLI transfer boundary, not a hand-written Store round trip."""
+
+import json
+import subprocess
+import sys
+
+import pytest
+
+from kindex.config import Config
+from kindex.store import Store
+from kindex.trust import node_trust_decision
+
+
+def cli(data_dir, *args):
+    return subprocess.run(
+        [sys.executable, "-m", "kindex.cli", *args,
+         "--data-dir", str(data_dir), "--config", "/dev/null"],
+        capture_output=True, text=True, timeout=30,
+    )
+
+
+def snapshot(store):
+    return {
+        table: [tuple(row) for row in store.conn.execute(f"SELECT * FROM {table} ORDER BY id")]
+        for table in ("nodes", "edges", "activity_log")
+    }
+
+
+@pytest.mark.parametrize("fmt", ["json", "jsonl"])
+def test_cli_transfer_preserves_lifecycle_without_importing_authority(tmp_path, fmt):
+    source_dir, dest_dir = tmp_path / "source", tmp_path / "dest"
+    source = Store(Config(data_dir=str(source_dir)))
+    for node_id, status, extra in (
+        ("retired", "superseded", {"superseded_by": "current"}),
+        ("expired", "archived", {"expires": "2020-01-01", "expired_at": "2020-01-02"}),
+        ("stale", "active", {"referent_stale": {"reason": "digest-mismatch"}}),
+        ("current", "active", {}),
+    ):
+        source.add_node(
+            "Shared title", node_id=node_id, content=f"Claim {node_id}",
+            status=status, extra=extra, audience="team",
+            prov_source="https://github.com/wandercom/kindex/blob/main/README.md",
+            referent={"url": "https://example.com/evidence", "content_digest": "a" * 64},
+            asserted_at="2026-01-01T00:00:00Z", true_of="2025-12-31T00:00:00Z",
+        )
+        source.verify_node(node_id, verified_by="source-reviewer", prov_method="human review",
+                           verified_at="2026-01-02T00:00:00Z",
+                           valid_at="2026-01-01T00:00:00Z",
+                           invalid_at="2026-02-01T00:00:00Z" if node_id == "retired" else None)
+    source.add_edge("current", "retired", "supersedes", bidirectional=False)
+    source.add_edge("stale", "current", "contradicts", bidirectional=False)
+    originals = {n["id"]: n for n in source.all_nodes()}
+    source.close()
+
+    exported = cli(source_dir, "export", "--audience", "private", "--format", fmt)
+    assert exported.returncode == 0, exported.stderr
+    transfer = tmp_path / f"graph.{fmt}"
+    transfer.write_text(exported.stdout)
+    imported = cli(dest_dir, "import", str(transfer))
+    assert imported.returncode == 0, imported.stderr
+    dest = Store(Config(data_dir=str(dest_dir)))
+    assert set(dest.node_ids()) == set(originals)
+    for node in dest.all_nodes():
+        original = originals[node["id"]]
+        for field in ("content", "status", "audience", "prov_source", "referent",
+                      "asserted_at", "true_of", "valid_at", "invalid_at", "created_at", "updated_at"):
+            assert node[field] == original[field], field
+        assert node["verified_at"] is None
+        assert node["verified_by"] is None
+        assert node["prov_method"] is None
+        for key, value in original["extra"].items():
+            assert node["extra"][key] == value
+        assert node["extra"]["imported_verification"]["verified_by"] == "source-reviewer"
+        assert not node_trust_decision(dest, node).eligible
+    assert [(e["to_id"], e["type"]) for e in dest.edges_from("stale")] == [("current", "contradicts")]
+    before = snapshot(dest)
+    replay = cli(dest_dir, "import", str(transfer))
+    assert replay.returncode == 0, replay.stderr
+    assert snapshot(dest) == before
+    dest.close()
+
+
+def test_cli_import_conflict_is_atomic_and_does_not_concatenate(tmp_path):
+    data_dir = tmp_path / "data"
+    store = Store(Config(data_dir=str(data_dir)))
+    store.add_node("Existing", content="Original claim", node_id="existing")
+    before = snapshot(store)
+    transfer = tmp_path / "graph.json"
+    transfer.write_text(json.dumps([
+        {"id": "new", "title": "New"},
+        {"id": "existing", "title": "Existing", "content": "Opposite claim"},
+    ]))
+    result = cli(data_dir, "import", str(transfer))
+    assert result.returncode != 0
+    assert "conflict" in result.stderr.lower()
+    assert snapshot(store) == before
+    store.close()
+
+
+@pytest.mark.parametrize("mode", ["merge", "replace"])
+def test_edge_hydration_and_legacy_replay_do_not_clear_state(tmp_path, mode):
+    data_dir = tmp_path / "data"
+    store = Store(Config(data_dir=str(data_dir)))
+    store.add_node("First", node_id="a", content="Keep this", status="archived",
+                   extra={"expires": "2020-01-01"})
+    store.add_node("Second", node_id="b")
+    before = [tuple(row) for row in store.conn.execute("SELECT * FROM nodes ORDER BY id")]
+    transfer = tmp_path / "edges.json"
+    transfer.write_text(json.dumps([{"id": "a", "title": "First", "edges": [{"to": "b"}]}]))
+    result = cli(data_dir, "import", str(transfer), "--mode", mode)
+    assert result.returncode == 0, result.stderr
+    assert [tuple(row) for row in store.conn.execute("SELECT * FROM nodes ORDER BY id")] == before
+    assert len(store.edges_from("a")) == len(store.edges_from("b")) == 1
+    before = snapshot(store)
+    assert cli(data_dir, "import", str(transfer), "--mode", mode).returncode == 0
+    assert snapshot(store) == before
+    store.close()
+
+
+def test_legacy_title_ids_forward_edges_and_missing_clocks_are_stable(tmp_path):
+    data_dir = tmp_path / "data"
+    transfer = tmp_path / "legacy.json"
+    transfer.write_text(json.dumps([
+        {"title": "First", "edges": [{"to": "Second"}],
+         "referent": {"url": "https://example.com", "content_digest": "a" * 64}},
+        {"title": "Second"},
+    ]))
+    assert cli(data_dir, "import", str(transfer)).returncode == 0
+    store = Store(Config(data_dir=str(data_dir)))
+    before = snapshot(store)
+    assert len(store.node_ids()) == 2
+    assert all(n["asserted_at"] is None and n["true_of"] is None for n in store.all_nodes())
+    assert cli(data_dir, "import", str(transfer)).returncode == 0
+    assert snapshot(store) == before
+    exported = cli(data_dir, "export", "--audience", "private", "--format", "json")
+    assert exported.returncode == 0, exported.stderr
+    transfer.write_text(exported.stdout)
+    replay = cli(tmp_path / "second-dest", "import", str(transfer))
+    assert replay.returncode == 0, replay.stderr
+    store.close()
+
+
+@pytest.mark.parametrize("invalid", [
+    {"audience": "unknown"}, {"extra": {"expires": "2026-99-01"}},
+    {"invalid_at": "yesterday"}, {"weight": float("nan")},
+    {"referent": {"path": "missing-digest"}}, {"edges": [{"to": "absent"}]},
+    {"extra": {"referent_stale": "nope"}}, {"edges": "not-a-list"},
+])
+def test_invalid_import_rolls_back_every_record(tmp_path, invalid):
+    data_dir = tmp_path / "data"
+    store = Store(Config(data_dir=str(data_dir)))
+    before = snapshot(store)
+    transfer = tmp_path / "bad.json"
+    transfer.write_text(json.dumps([{"id": "first", "title": "First"},
+                                   {"id": "second", "title": "Second", **invalid}]))
+    result = cli(data_dir, "import", str(transfer))
+    assert result.returncode != 0
+    assert snapshot(store) == before
+    store.close()
+
+
+@pytest.mark.parametrize("incoming", [
+    {"status": "active"}, {"audience": "public"}, {"invalid_at": None},
+    {"invalid_at": "2027-01-01T00:00:00Z"}, {"valid_at": None},
+    {"invalid_at": "2020-01-01T00:00:00.1Z"},
+    {"extra": {"expires": "2027-01-01"}}, {"extra": {"referent_stale": {}}},
+])
+def test_replace_cannot_revive_or_publish_old_claims(tmp_path, incoming):
+    data_dir = tmp_path / "data"
+    store = Store(Config(data_dir=str(data_dir)))
+    store.add_node("Old", node_id="old", status="archived", audience="private",
+                   extra={"expires": "2020-01-01", "referent_stale": {"reason": "digest-mismatch"}})
+    store.verify_node("old", verified_by="reviewer", prov_method="inspection",
+                      valid_at="2019-01-01T00:00:00Z", invalid_at="2020-01-01T00:00:00Z")
+    before = snapshot(store)
+    transfer = tmp_path / "replace.json"
+    transfer.write_text(json.dumps([{"id": "old", **incoming}]))
+    assert cli(data_dir, "import", str(transfer), "--mode", "replace").returncode != 0
+    assert snapshot(store) == before
+    store.close()
+
+
+def test_replacement_revokes_local_verification_and_dry_run_is_read_only(tmp_path):
+    data_dir = tmp_path / "data"
+    store = Store(Config(data_dir=str(data_dir)))
+    store.add_node("Claim", node_id="claim", content="Original")
+    store.verify_node("claim", verified_by="reviewer", prov_method="inspection")
+    before = snapshot(store)
+    transfer = tmp_path / "replace.json"
+    transfer.write_text(json.dumps([{"id": "claim", "content": "Replacement"}]))
+    assert cli(data_dir, "import", str(transfer), "--mode", "replace", "--dry-run").returncode == 0
+    assert snapshot(store) == before
+    assert cli(data_dir, "import", str(transfer), "--mode", "replace").returncode == 0
+    node = store.get_node("claim")
+    assert node["content"] == "Replacement"
+    assert node["verified_at"] is None
+    assert not node_trust_decision(store, node).eligible
+    store.close()
+
+
+@pytest.mark.parametrize("audience", ["org", "public"])
+def test_shared_exports_preserve_urls_but_not_private_metadata(tmp_path, audience):
+    data_dir = tmp_path / "data"
+    store = Store(Config(data_dir=str(data_dir)))
+    store.add_node("Private", node_id="hidden-id", audience="private")
+    store.add_node(
+        "Published", node_id="published", audience="public", status="superseded",
+        prov_who=["private-actor"], prov_activity="private-actor capture", intent="private-actor thought",
+        prov_source="https://github.com/wandercom/kindex/blob/main/README.md",
+        referent={"path": "/Users/private-actor/work/code.py", "content_digest": "a" * 64},
+        extra={"superseded_by": "hidden-id", "actor": "private-actor",
+               "action_command": "echo never-import-this", "lock": {"agent": "private-actor"},
+               "referent_stale": {"reason": "digest-mismatch", "actor": "private-actor"},
+               "imported_verification": {"verified_by": "private-actor", "prov_method": "private-actor inspected"}},
+    )
+    store.verify_node("published", verified_by="private-actor", prov_method="private-actor inspected")
+    store.add_edge("published", "hidden-id")
+    store.close()
+    exported = cli(data_dir, "export", "--audience", audience, "--format", "json")
+    assert exported.returncode == 0, exported.stderr
+    assert "private-actor" not in exported.stdout
+    assert "hidden-id" not in exported.stdout
+    assert "never-import-this" not in exported.stdout
+    record, = json.loads(exported.stdout)
+    assert record["prov_source"] == "https://github.com/wandercom/kindex/blob/main/README.md"
+    assert record["referent"]["content_digest"] == "a" * 64
+    assert record["referent"]["path_redacted"]
+    transfer = tmp_path / "public.json"
+    transfer.write_text(exported.stdout)
+    assert cli(tmp_path / "dest", "import", str(transfer)).returncode == 0
+    dest = Store(Config(data_dir=str(tmp_path / "dest")))
+    node = dest.get_node("published")
+    assert node["status"] == "superseded"
+    assert node["referent"] is None
+    assert node["extra"]["imported_referent"]["content_digest"] == "a" * 64
+    dest.close()
+
+
+def test_import_cannot_install_runtime_controls_or_forge_verification(tmp_path):
+    from kindex.graph_transfer import import_records
+
+    store = Store(Config(data_dir=str(tmp_path / "data")))
+    import_records(store, [{
+        "id": "claim", "title": "Claim", "verified_by": "arbitrary-imported-user",
+        "verified_at": "2026-01-01T00:00:00Z", "prov_method": "claimed inspection",
+        "extra": {"actor": "arbitrary-imported-user", "lock": {"agent": "attacker"},
+                  "action_command": "echo never-run", "task_status": "active"},
+    }])
+    node = store.get_node("claim")
+    assert set(node["extra"]) == {"imported_verification"}
+    assert node_trust_decision(store, node).reason == "unverified"
+    store.close()
+
+
+def test_import_audit_failure_rolls_back_nodes_and_edges(tmp_path, monkeypatch):
+    from kindex.graph_transfer import import_records
+
+    store = Store(Config(data_dir=str(tmp_path / "data")))
+    before = snapshot(store)
+    log = store._log_in_transaction
+
+    def fail_on_edges(conn, action, *args, **kwargs):
+        if action == "import_edges":
+            raise RuntimeError("simulated audit failure")
+        log(conn, action, *args, **kwargs)
+
+    monkeypatch.setattr(store, "_log_in_transaction", fail_on_edges)
+    with pytest.raises(RuntimeError, match="audit failure"):
+        import_records(store, [{"id": "a", "title": "A", "edges": [{"to": "b"}]},
+                               {"id": "b", "title": "B"}])
+    assert snapshot(store) == before
+    store.close()
+
+
+def test_export_does_not_silently_truncate_large_graphs(tmp_path):
+    data_dir = tmp_path / "data"
+    store = Store(Config(data_dir=str(data_dir)))
+    store.conn.executemany("INSERT INTO nodes (id, title) VALUES (?, ?)",
+                           ((f"node-{i}", f"Node {i}") for i in range(10001)))
+    store.conn.commit()
+    store.close()
+    exported = cli(data_dir, "export", "--audience", "private", "--format", "json")
+    assert exported.returncode == 0, exported.stderr
+    assert len(json.loads(exported.stdout)) == 10001

--- a/tests/test_graph_transfer.py
+++ b/tests/test_graph_transfer.py
@@ -3,6 +3,7 @@
 import json
 import subprocess
 import sys
+from pathlib import Path
 
 import pytest
 
@@ -282,3 +283,169 @@ def test_export_does_not_silently_truncate_large_graphs(tmp_path):
     exported = cli(data_dir, "export", "--audience", "private", "--format", "json")
     assert exported.returncode == 0, exported.stderr
     assert len(json.loads(exported.stdout)) == 10001
+
+
+@pytest.mark.parametrize("fmt", ["json", "jsonl"])
+@pytest.mark.parametrize("clocks", [
+    {}, {"asserted_at": None, "true_of": None},
+    {"asserted_at": "2026-01-01T00:00:00Z", "true_of": None},
+    {"asserted_at": None, "true_of": "2026-01-01T00:00:00Z"},
+])
+def test_unknown_clocks_survive_every_cli_hop(tmp_path, clocks, fmt):
+    transfer = tmp_path / f"snapshot.{fmt}"
+    item = {"id": "bound", "title": "Unknown observation time", **clocks,
+            "referent": {"url": "https://example.com", "content_digest": "a" * 64}}
+    transfer.write_text(json.dumps([item]) if fmt == "json" else json.dumps(item))
+    for hop in range(3):
+        data_dir = tmp_path / f"hop-{hop}"
+        result = cli(data_dir, "import", str(transfer))
+        assert result.returncode == 0, result.stderr
+        store = Store(Config(data_dir=str(data_dir)))
+        node = store.get_node("bound")
+        assert {k: node[k] for k in ("asserted_at", "true_of")} == {
+            k: clocks.get(k) for k in ("asserted_at", "true_of")}
+        before = snapshot(store)
+        replay = cli(data_dir, "import", str(transfer))
+        assert replay.returncode == 0, replay.stderr
+        assert snapshot(store) == before
+        store.close()
+        exported = cli(data_dir, "export", "--audience", "private", "--format", fmt)
+        assert exported.returncode == 0, exported.stderr
+        transfer.write_text(exported.stdout)
+
+
+def test_cli_merge_fills_extra_keys_and_still_rejects_conflicts(tmp_path):
+    data_dir = tmp_path / "data"
+    store = Store(Config(data_dir=str(data_dir)))
+    store.add_node("Claim", node_id="claim", content="Unchanged", extra={"expires": "2027-01-01"})
+    transfer = tmp_path / "metadata.json"
+    added = {"referent_stale": {"reason": "digest-mismatch"},
+             "imported_verification": {"verified_by": "upstream-reviewer"}}
+    transfer.write_text(json.dumps({"id": "claim", "extra": added}))
+    result = cli(data_dir, "import", str(transfer))
+    assert result.returncode == 0, result.stderr
+    node = store.get_node("claim")
+    assert node["extra"] == {"expires": "2027-01-01", **added}
+    assert node["content"] == "Unchanged"
+    assert node_trust_decision(store, node).reason == "unverified"
+    before = snapshot(store)
+    assert cli(data_dir, "import", str(transfer)).returncode == 0
+    assert snapshot(store) == before
+    transfer.write_text(json.dumps({"id": "claim", "extra": {"expires": "2026-01-01"}}))
+    assert cli(data_dir, "import", str(transfer)).returncode != 0
+    assert snapshot(store) == before
+    store.close()
+
+
+@pytest.mark.parametrize("path", [r"C:\Users\private-user\code.py", r"C:private-user\code.py",
+                                  r"\\server\private-user\code.py", "/Users/private-user/code.py"])
+@pytest.mark.parametrize("audience", ["org", "public"])
+def test_shared_path_redaction_is_cross_platform(tmp_path, path, audience):
+    data_dir = tmp_path / "data"
+    store = Store(Config(data_dir=str(data_dir)))
+    binding = {"path": path, "content_digest": "a" * 64, "digest_scope": "file"}
+    store.add_node("Claim", node_id="claim", audience="public", referent=binding,
+                   prov_source=path, extra={"imported_referent": binding})
+    store.close()
+    exported = cli(data_dir, "export", "--audience", audience, "--format", "json")
+    assert exported.returncode == 0, exported.stderr
+    assert "private-user" not in exported.stdout
+    node, = json.loads(exported.stdout)
+    assert node["prov_source"] == "code.py"
+    assert node["referent"]["path_redacted"] is True
+    assert node["extra"]["imported_referent"]["path_redacted"] is True
+
+
+@pytest.mark.parametrize("changed", [{"weight": 0.9}, {"provenance": "new evidence"}])
+def test_cli_edge_conflicts_rollback_and_replace_explicitly(tmp_path, changed):
+    data_dir = tmp_path / "data"
+    store = Store(Config(data_dir=str(data_dir)))
+    for node_id in ("a", "b"):
+        store.add_node(node_id, node_id=node_id)
+    store.add_edge("a", "b", weight=0.5, provenance="old evidence", bidirectional=False)
+    before = snapshot(store)
+    transfer = tmp_path / "edges.json"
+    transfer.write_text(json.dumps([
+        {"id": "new", "title": "Must roll back"},
+        {"id": "a", "edges": [{"to": "b", "bidirectional": False, **changed}]},
+    ]))
+    result = cli(data_dir, "import", str(transfer))
+    assert result.returncode != 0
+    assert "conflict" in result.stderr.lower()
+    assert snapshot(store) == before
+    assert cli(data_dir, "import", str(transfer), "--mode", "replace", "--dry-run").returncode == 0
+    assert snapshot(store) == before
+    result = cli(data_dir, "import", str(transfer), "--mode", "replace")
+    assert result.returncode == 0, result.stderr
+    edge, = store.edges_from("a")
+    assert edge["weight"] == changed.get("weight", 0.5)
+    assert edge["provenance"] == changed.get("provenance", "old evidence")
+    before = snapshot(store)
+    assert cli(data_dir, "import", str(transfer), "--mode", "replace").returncode == 0
+    assert snapshot(store) == before
+    store.close()
+
+
+@pytest.mark.parametrize("reverse_order", [False, True])
+def test_legacy_two_way_edges_keep_declared_weights_regardless_of_order(tmp_path, reverse_order):
+    records = [{"id": "a", "title": "A", "edges": [{"to": "b", "weight": 0.5}]},
+               {"id": "b", "title": "B", "edges": [{"to": "a", "weight": 0.4}]}]
+    transfer = tmp_path / "legacy.json"
+    transfer.write_text(json.dumps(records[::-1] if reverse_order else records))
+    data_dir = tmp_path / "data"
+    result = cli(data_dir, "import", str(transfer))
+    assert result.returncode == 0, result.stderr
+    store = Store(Config(data_dir=str(data_dir)))
+    assert store.edges_from("a")[0]["weight"] == 0.5
+    assert store.edges_from("b")[0]["weight"] == 0.4
+    before = snapshot(store)
+    assert cli(data_dir, "import", str(transfer)).returncode == 0
+    assert snapshot(store) == before
+    store.close()
+
+
+@pytest.mark.parametrize("mode", ["merge", "replace"])
+def test_conflicting_duplicate_arcs_in_one_file_are_rejected(tmp_path, mode):
+    data_dir = tmp_path / "data"
+    store = Store(Config(data_dir=str(data_dir)))
+    before = snapshot(store)
+    transfer = tmp_path / "bad-edges.json"
+    transfer.write_text(json.dumps([
+        {"id": "a", "title": "A", "edges": [{"to": "b", "weight": 0.1}, {"to": "b", "weight": 0.9}]},
+        {"id": "b", "title": "B"},
+    ]))
+    result = cli(data_dir, "import", str(transfer), "--mode", mode)
+    assert result.returncode != 0
+    assert "conflict" in result.stderr.lower()
+    assert snapshot(store) == before
+    store.close()
+
+
+def test_installed_console_script_transfers_and_reopens_for_recall(tmp_path):
+    executable = Path(sys.executable).with_name("kin")
+    assert executable.is_file(), "Install the package before running its console E2E test"
+
+    def run(data_dir, *args):
+        return subprocess.run([str(executable), *args, "--data-dir", str(data_dir), "--config", "/dev/null"],
+                              capture_output=True, text=True, timeout=30)
+
+    transfer = tmp_path / "input.json"
+    transfer.write_text(json.dumps([{
+        "id": "claim", "title": "transfercanary", "content": "transfercanary unverified evidence",
+        "audience": "org", "verified_by": "upstream", "verified_at": "2026-01-01T00:00:00Z",
+        "prov_method": "claimed review", "prov_source": "https://example.com/evidence",
+    }]))
+    source, dest = tmp_path / "source", tmp_path / "dest"
+    assert run(source, "import", str(transfer)).returncode == 0
+    result = run(source, "export", "--audience", "org", "--format", "jsonl")
+    assert result.returncode == 0, result.stderr
+    transfer = tmp_path / "export.jsonl"
+    transfer.write_text(result.stdout)
+    assert run(dest, "import", str(transfer)).returncode == 0
+    recall = run(dest, "search", "transfercanary", "--json")
+    assert recall.returncode == 0, recall.stderr
+    assert [n["id"] for n in json.loads(recall.stdout)] == ["claim"]
+    trusted = run(dest, "search", "transfercanary", "--trusted-only", "--json")
+    assert trusted.returncode == 0, trusted.stderr
+    assert not trusted.stdout.strip()
+    assert "No results." in trusted.stderr


### PR DESCRIPTION
## Summary

Fixes graph export/import correctness for [TOOL-1160](https://linear.app/wander/issue/TOOL-1160).

- Preserve lifecycle, referents, source provenance and identity without treating imported verification claims as local authority.
- Use one SQLite transaction for nodes, edges and audit; reject conflicts instead of concatenating claims, resolve forward references, and make repeated imports stable.
- Preserve exact exported edge directions, prevent audience/lifecycle widening, redact private metadata and avoid the silent 10,000-node export cutoff.
- Retain JSON/JSONL and legacy title/edge compatibility, with documented conflict/replacement semantics. No new dependencies, schema or service.

## Validation

Revision [23d46ab](https://github.com/wandercom/kindex/commit/23d46ab62e2b7baaec61e42012f9a334fea05a3f) fixes all six review threads (four root causes): missing lifecycle-key fill-in, fabricated null clocks, cross-platform shared-path leakage, and silently ignored edge conflicts/replacements.

- New CLI regressions reproduced the review failures before correction.
- **Full source suite: 2,214 passed, zero skipped** (132 seconds).
- **Full non-editable wheel suite: 2,214 passed, zero skipped** (131 seconds), run outside the source checkout with PYTHONPATH unset.
- **52 transfer cases** exercise actual CLI processes and SQLite: three-hop JSON/JSONL replay, lifecycle/trust/privacy boundaries, forward and legacy reverse arcs, merge conflict rollback, explicit replacement, dry-run, duplicate declarations, large snapshots and installed-console search/trusted-search behavior.
- Built source/wheel distributions; `make verify-dist-install`, `make test-isolation`, `make lint` and `git diff --check` passed.
- Full coverage environment: Python 3.12.9, `[dev,all]`, tree-sitter + Python/Rust grammars, and temporary Universal Ctags 6.2.1 with JSON support. No global tool installation, paid model call or production data was used.

The pre-existing hook-migration failure was an environment-dependent test fixture: it hardcodes a Homebrew installation but previously compared it with the runner's different venv binary. The fixture now pins its own installation path; production hook ownership checks are unchanged. The previously skipped optional Rust integration also ran and passed with its actual parser dependencies available.

## Boundaries

No PyPI release, production graph mutation or changes to repository permissions. Import remains evidence transport, not a task/runtime backup or a substitute for the existing `repo-memory` candidate review flow. Missing or conflicting metadata fails visibly rather than silently reviving a claim.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core graph I/O and trust semantics (verification, audience, lifecycle guards) in SQLite transactions; mistakes could corrupt or over-share knowledge, but behavior is fail-closed with extensive regression tests.
> 
> **Overview**
> **Graph transfer** is reworked around a new `graph_transfer` module so `kin export` / `kin import` move **knowledge snapshots** (not runtime state) with predictable semantics.
> 
> **Export** now loads all nodes for the chosen audience (no silent **10,000-node** cap), builds records via `export_record` (lifecycle `extra`, referents, clocks, directed edges), and tightens org/public redaction (preserve http(s) sources, basename-only local paths, cross-platform path stripping in `_strip_pii`).
> 
> **Import** replaces per-record merge that **concatenated conflicting content** with a **single SQLite transaction**: validate → nodes → edges, `--dry-run` rollback, idempotent replay, merge fills gaps but **fails on conflicts**, replace updates supplied fields and **clears local verification**. Upstream verification lands in `extra.imported_verification` only; imports cannot widen audience, reactivate inactive nodes, relax validity/expiry, or smuggle locks/tasks. Edge handling respects explicit direction, legacy bidirectional defaults, and replace-only weight/provenance updates.
> 
> The human guide documents transfer boundaries and validation; **`tests/test_graph_transfer.py`** exercises CLI subprocesses, privacy, trust, and rollback. Hook migration test pins `_find_kin_path` for fixture-accurate ownership checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 23d46ab62e2b7baaec61e42012f9a334fea05a3f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->