### PR TITLE
fix: prevent stale reminder replay after automatic snooze

### DIFF
--- a/README.md
+++ b/README.md
@@ -1124,6 +1124,7 @@ reminders:
   default_channels: [system]     # system, slack, email, claude, terminal
   snooze_duration: 900           # 15 min default snooze
   auto_snooze_timeout: 300       # auto-snooze after 5 min inaction
+  max_action_overdue: 86400      # stale actions notify only; 0 disables guard
   idle_suppress_after: 600       # suppress if idle > 10 min
   stop_guard_enabled: false      # opt-in; blocking Stop hooks are noisy in Claude
   dream_on_stop_enabled: true    # launch throttled detached dream from Claude Stop hook
@@ -1138,6 +1139,13 @@ reminders:
       smtp_host: ""
       to_addr: ""
 ```
+
+Automatic snoozes retry notifications without extending an action's freshness
+window. A deliberate `kin remind snooze` defers that window to the snooze expiry;
+`kin remind exec` runs an action deliberately. Older snoozes without provenance
+retain their previous deferral semantics, since automatic and manual snoozes
+were historically stored identically. This change does not classify or repair
+an existing reminder backlog.
 
 Use `kin attention estimate --messages 1000` to estimate cost over a fixed prompt window. Conversation accounting is retained when a client provides a stable session id. Hook-driven attention does not fall back to cwd as a fake conversation id, because that would cross-pollute two chats open in the same repo.
 

--- a/src/kindex/actions.py
+++ b/src/kindex/actions.py
@@ -158,11 +158,10 @@ def _update_action_status(
     store: Store, rid: str, reminder: dict, status: str, result: str,
 ) -> None:
     """Write ``action_status`` and ``action_result`` into the reminder's extra."""
-    extra = dict(reminder.get("extra") or {})
-    extra["action_status"] = status
-    extra["action_result"] = redact_text(result)[:4000]
-    extra["action_executed_at"] = datetime.datetime.now().isoformat(timespec="seconds")
-    store.update_reminder(rid, extra=extra)
+    store.update_reminder_action(
+        rid, status=status, result=redact_text(result)[:4000],
+        executed_at=datetime.datetime.now().isoformat(timespec="seconds"),
+    )
 
 
 def _run_shell(command: str, *, timeout: int = 300) -> dict:

--- a/src/kindex/reminders.py
+++ b/src/kindex/reminders.py
@@ -740,8 +740,8 @@ def auto_snooze_stale(store: Store, config: Config) -> int:
         snooze_until = (now + datetime.timedelta(seconds=snooze_duration)).isoformat(
             timespec="seconds"
         )
-        store.snooze_reminder(r["id"], snooze_until, automatic=True)
-        count += 1
+        if store.snooze_reminder(r["id"], snooze_until, automatic=True):
+            count += 1
 
     return count
 

--- a/src/kindex/reminders.py
+++ b/src/kindex/reminders.py
@@ -501,6 +501,9 @@ def advance_recurring(store: Store, reminder_id: str) -> str | None:
     # "paused" (staleness parking) is also preserved — only a deliberate
     # manual exec may resume a parked job.
     extra = dict(r.get("extra") or {})
+    if "action_snooze_until" in extra:
+        del extra["action_snooze_until"]
+        updates["extra"] = extra
     if extra.get("action_status") and extra["action_status"] not in ("running", "paused"):
         extra["action_status"] = "pending"
         updates["extra"] = extra
@@ -578,17 +581,18 @@ def _release_check_lock(store: Store, token: str) -> None:
 def _action_is_stale(reminder: dict, config: Config) -> bool:
     """True when a due reminder's action is too overdue to auto-execute.
 
-    Staleness anchors to the effective trigger time: a snoozed reminder was
-    explicitly deferred, so its snooze expiry — not the original next_due —
-    is when it became actionable. Without that anchor a deliberate 48h snooze
-    would be misclassified as an abandoned backlog the moment it expired.
+    A deliberate snooze defers the action deadline; automatic notification
+    retries do not. Legacy snoozes without provenance retain their existing
+    semantics, since they may be deliberate long deferrals.
     """
     max_overdue = int(getattr(config.reminders, "max_action_overdue", 86400) or 0)
     if max_overdue <= 0:
         return False
     try:
         anchor = datetime.datetime.fromisoformat(reminder["next_due"])
-        snooze = reminder.get("snooze_until")
+        snooze = (reminder.get("extra") or {}).get(
+            "action_snooze_until", reminder.get("snooze_until")
+        )
         if snooze:
             anchor = max(anchor, datetime.datetime.fromisoformat(snooze))
         return (_now_dt() - anchor).total_seconds() > max_overdue
@@ -736,7 +740,7 @@ def auto_snooze_stale(store: Store, config: Config) -> int:
         snooze_until = (now + datetime.timedelta(seconds=snooze_duration)).isoformat(
             timespec="seconds"
         )
-        store.snooze_reminder(r["id"], snooze_until)
+        store.snooze_reminder(r["id"], snooze_until, automatic=True)
         count += 1
 
     return count

--- a/src/kindex/reminders.py
+++ b/src/kindex/reminders.py
@@ -455,6 +455,19 @@ def advance_recurring(store: Store, reminder_id: str) -> str | None:
 
     Returns the new next_due ISO string, or None if no more occurrences.
     """
+    # Schedule cleanup and action-state reset must use the same fresh snapshot.
+    # Otherwise a concurrent manual resume can be overwritten with stale paused
+    # metadata when we remove the previous occurrence's snooze deadline.
+    store.conn.execute("BEGIN IMMEDIATE")
+    try:
+        return _advance_recurring_locked(store, reminder_id)
+    except BaseException:
+        store.conn.rollback()
+        raise
+
+
+def _advance_recurring_locked(store: Store, reminder_id: str) -> str | None:
+    """Advance under the write lock; the store update commits the transaction."""
     r = store.get_reminder(reminder_id)
     if r is None:
         raise ValueError(f"Reminder not found: {reminder_id}")

--- a/src/kindex/store.py
+++ b/src/kindex/store.py
@@ -4305,19 +4305,30 @@ class Store:
 
     def snooze_reminder(
         self, reminder_id: str, snooze_until: str, increment_count: bool = True,
+        *, automatic: bool = False,
     ) -> None:
-        """Set a reminder to snoozed status."""
+        """Snooze notifications; only a deliberate snooze defers action freshness.
+
+        Old records have no separate action deadline. Preserve their existing
+        snooze on the first automatic retry rather than guessing its origin.
+        """
         fields: dict[str, Any] = {
             "status": "snoozed",
             "snooze_until": snooze_until,
         }
-        if increment_count:
-            r = self.get_reminder(reminder_id)
-            if r:
+        r = self.get_reminder(reminder_id)
+        if r:
+            extra = dict(r.get("extra") or {})
+            if automatic:
+                extra.setdefault("action_snooze_until", r.get("snooze_until"))
+            else:
+                extra["action_snooze_until"] = snooze_until
+            fields["extra"] = extra
+            if increment_count:
                 fields["snooze_count"] = r.get("snooze_count", 0) + 1
         self.update_reminder(reminder_id, **fields)
         self._log("snooze_reminder", reminder_id, "",
-                  details={"snooze_until": snooze_until})
+                  details={"snooze_until": snooze_until, "automatic": automatic})
 
     def complete_reminder(self, reminder_id: str) -> None:
         """Mark a reminder as completed."""

--- a/src/kindex/store.py
+++ b/src/kindex/store.py
@@ -4306,18 +4306,25 @@ class Store:
     def snooze_reminder(
         self, reminder_id: str, snooze_until: str, increment_count: bool = True,
         *, automatic: bool = False,
-    ) -> None:
+    ) -> bool:
         """Snooze notifications; only a deliberate snooze defers action freshness.
 
         Old records have no separate action deadline. Preserve their existing
         snooze on the first automatic retry rather than guessing its origin.
+        Returns whether a row was snoozed. Automatic retries only claim fired
+        rows; completion/cancellation and manual snoozes win if committed first.
         """
-        fields: dict[str, Any] = {
-            "status": "snoozed",
-            "snooze_until": snooze_until,
-        }
-        r = self.get_reminder(reminder_id)
-        if r:
+        conn = self.conn
+        conn.execute("BEGIN IMMEDIATE")
+        try:
+            r = self.get_reminder(reminder_id)
+            if not r or (automatic and r["status"] != "fired"):
+                conn.rollback()
+                return False
+            fields: dict[str, Any] = {
+                "status": "snoozed",
+                "snooze_until": snooze_until,
+            }
             extra = dict(r.get("extra") or {})
             if automatic:
                 extra.setdefault("action_snooze_until", r.get("snooze_until"))
@@ -4326,9 +4333,32 @@ class Store:
             fields["extra"] = extra
             if increment_count:
                 fields["snooze_count"] = r.get("snooze_count", 0) + 1
-        self.update_reminder(reminder_id, **fields)
+            self.update_reminder(reminder_id, **fields)
+        except BaseException:
+            conn.rollback()
+            raise
         self._log("snooze_reminder", reminder_id, "",
                   details={"snooze_until": snooze_until, "automatic": automatic})
+        return True
+
+    def update_reminder_action(
+        self, reminder_id: str, *, status: str, result: str, executed_at: str,
+    ) -> None:
+        """Update action fields without losing a concurrent snooze's deadline."""
+        conn = self.conn
+        conn.execute("BEGIN IMMEDIATE")
+        try:
+            r = self.get_reminder(reminder_id)
+            if not r:
+                conn.rollback()
+                return
+            extra = dict(r.get("extra") or {})
+            extra.update(action_status=status, action_result=result,
+                         action_executed_at=executed_at)
+            self.update_reminder(reminder_id, extra=extra)
+        except BaseException:
+            conn.rollback()
+            raise
 
     def complete_reminder(self, reminder_id: str) -> None:
         """Mark a reminder as completed."""

--- a/tests/test_reminder_auto_snooze.py
+++ b/tests/test_reminder_auto_snooze.py
@@ -102,3 +102,91 @@ def test_legacy_unmarked_snooze_keeps_deliberate_deferral_semantics(cycle):
                           last_fired="2026-06-01T12:00:00", snooze_count=12)
     reminders.check_and_fire(store, config)
     run.assert_called_once()
+
+
+class BeforeReminderWrite:
+    """Commit through a second connection immediately before the snooze write."""
+
+    def __init__(self, conn, callback):
+        self.conn = conn
+        self.callback = callback
+
+    def __getattr__(self, name):
+        return getattr(self.conn, name)
+
+    def execute(self, sql, *args):
+        if self.callback and (
+            sql.lstrip().startswith("UPDATE reminders") or sql == "BEGIN IMMEDIATE"
+        ):
+            callback, self.callback = self.callback, None
+            callback()
+        return self.conn.execute(sql, *args)
+
+
+@pytest.mark.parametrize("automatic", [False, True])
+def test_snooze_does_not_replay_concurrent_manual_completion(cycle, monkeypatch, automatic):
+    store, config, now, notify, run = cycle
+    rid = add_action(store, due=now[0].isoformat())
+    config.reminders.action_enabled = False
+    reminders.check_and_fire(store, config)
+    config.reminders.action_enabled = True
+    other = Store(config)
+    try:
+        def finish_action():
+            assert actions.execute_action(other, other.get_reminder(rid), config,
+                                          manual=True)["status"] == "completed"
+
+        monkeypatch.setattr(store, "_conn", BeforeReminderWrite(store.conn, finish_action))
+        now[0] += datetime.timedelta(seconds=config.reminders.auto_snooze_timeout)
+        if automatic:
+            assert reminders.auto_snooze_stale(store, config) == 1
+        else:
+            reminders.snooze_reminder(store, rid, config=config)
+        now[0] += datetime.timedelta(seconds=config.reminders.snooze_duration)
+        reminders.check_and_fire(store, config)
+        run.assert_called_once()
+        extra = store.get_reminder(rid)["extra"]
+        assert extra["action_status"] == "completed"
+        assert extra["action_result"] == "mocked"
+    finally:
+        other.close()
+
+
+def test_action_finishing_after_auto_snooze_keeps_stale_deadline(cycle, monkeypatch):
+    store, config, now, notify, run = cycle
+    rid = add_action(store)
+    reminders.check_and_fire(store, config)
+    other = Store(config)
+    try:
+        def snooze_during_action(*args, **kwargs):
+            now[0] += datetime.timedelta(seconds=config.reminders.auto_snooze_timeout)
+            assert reminders.auto_snooze_stale(other, config) == 1
+            return {"ok": False, "output": "failed manual attempt"}
+
+        run.side_effect = snooze_during_action
+        assert actions.execute_action(store, store.get_reminder(rid), config,
+                                      manual=True)["status"] == "failed"
+        run.side_effect = None
+        now[0] += datetime.timedelta(seconds=config.reminders.snooze_duration)
+        reminders.check_and_fire(store, config)
+        run.assert_called_once()
+    finally:
+        other.close()
+
+
+@pytest.mark.parametrize("terminal", ["completed", "cancelled"])
+def test_auto_snooze_does_not_reopen_concurrent_terminal_reminder(cycle, monkeypatch, terminal):
+    store, config, now, notify, run = cycle
+    rid = add_action(store)
+    reminders.check_and_fire(store, config)
+    other = Store(config)
+    try:
+        monkeypatch.setattr(store, "_conn", BeforeReminderWrite(
+            store.conn, lambda: other.update_reminder(rid, status=terminal),
+        ))
+        now[0] += datetime.timedelta(seconds=config.reminders.auto_snooze_timeout)
+        assert reminders.auto_snooze_stale(store, config) == 0
+        assert store.get_reminder(rid)["status"] == terminal
+        run.assert_not_called()
+    finally:
+        other.close()

--- a/tests/test_reminder_auto_snooze.py
+++ b/tests/test_reminder_auto_snooze.py
@@ -1,0 +1,104 @@
+"""Automatic notification retries must not renew action freshness."""
+
+import datetime
+from unittest.mock import Mock
+
+import pytest
+
+from kindex import actions, reminders
+from kindex.config import Config
+from kindex.store import Store
+
+
+@pytest.fixture
+def cycle(tmp_path, monkeypatch):
+    now = [datetime.datetime(2026, 9, 10, 12)]
+    monkeypatch.setattr(reminders, "_now_dt", lambda: now[0])
+    monkeypatch.setattr(reminders, "_now", lambda: now[0].isoformat())
+    monkeypatch.setattr("kindex.store._now", lambda: now[0].isoformat())
+    monkeypatch.setattr(reminders, "_try_repack", lambda store: None)
+    notify = Mock(return_value=[])
+    monkeypatch.setattr("kindex.notify.dispatch", notify)
+    monkeypatch.setattr("kindex.notify.is_user_idle", lambda config: False)
+    run = Mock(return_value={"ok": True, "output": "mocked"})
+    for runner in ("_run_shell", "_run_claude", "_run_codex", "_run_opencode"):
+        monkeypatch.setattr(actions, runner, run)
+    config = Config(data_dir=str(tmp_path))
+    config.reminders.action_enabled = True
+    store = Store(config)
+    yield store, config, now, notify, run
+    store.close()
+
+
+def add_action(store, mode="shell", due="2026-06-01T12:00:00"):
+    return store.add_reminder("isolated replay", due, extra={
+        "action_command": "mocked-command",
+        "action_instructions": "mocked instructions",
+        "action_mode": mode,
+    })
+
+
+def auto_snooze_and_expire(store, config, now, rid):
+    now[0] += datetime.timedelta(seconds=config.reminders.auto_snooze_timeout)
+    assert reminders.auto_snooze_stale(store, config) == 1
+    assert store.get_reminder(rid)["status"] == "snoozed"
+    assert reminders.check_and_fire(store, config) == []
+    now[0] += datetime.timedelta(seconds=config.reminders.snooze_duration)
+
+
+@pytest.mark.parametrize("mode", ["shell", "claude", "codex", "opencode"])
+def test_stale_one_shot_stays_notification_only_through_auto_snooze(cycle, mode):
+    store, config, now, notify, run = cycle
+    rid = add_action(store, mode)
+    assert [r["id"] for r in reminders.check_and_fire(store, config)] == [rid]
+    assert store.get_reminder(rid)["status"] == "fired"
+    run.assert_not_called()
+    for _ in range(2):
+        auto_snooze_and_expire(store, config, now, rid)
+        assert [r["id"] for r in reminders.check_and_fire(store, config)] == [rid]
+        run.assert_not_called()
+        assert store.get_reminder(rid)["status"] == "fired"
+    assert notify.call_count == 3
+    # Explicit execution remains available even after repeated auto-snoozes.
+    assert actions.execute_action(store, store.get_reminder(rid), config,
+                                  manual=True)["status"] == "completed"
+    run.assert_called_once()
+
+
+def test_manual_snooze_after_auto_snooze_renews_deferral(cycle):
+    store, config, now, notify, run = cycle
+    rid = add_action(store)
+    reminders.check_and_fire(store, config)
+    auto_snooze_and_expire(store, config, now, rid)
+    reminders.snooze_reminder(store, rid, duration_seconds=2 * 86400)
+    now[0] += datetime.timedelta(days=2)
+    reminders.check_and_fire(store, config)
+    run.assert_called_once()
+    assert store.get_reminder(rid)["status"] == "completed"
+
+
+def test_auto_snooze_preserves_manual_deadline_without_extending_it(cycle):
+    store, config, now, notify, run = cycle
+    rid = add_action(store)
+    reminders.snooze_reminder(store, rid, duration_seconds=2 * 86400)
+    now[0] += datetime.timedelta(days=2)
+    run.return_value = {"ok": False, "output": "retryable failure"}
+    reminders.check_and_fire(store, config)
+    assert run.call_count == 1
+    auto_snooze_and_expire(store, config, now, rid)
+    reminders.check_and_fire(store, config)
+    assert run.call_count == 2  # still fresh relative to the manual deferral
+    now[0] += datetime.timedelta(seconds=config.reminders.max_action_overdue)
+    auto_snooze_and_expire(store, config, now, rid)
+    reminders.check_and_fire(store, config)
+    assert run.call_count == 2  # automatic deferral cannot renew it forever
+
+
+def test_legacy_unmarked_snooze_keeps_deliberate_deferral_semantics(cycle):
+    store, config, now, notify, run = cycle
+    rid = add_action(store)
+    # Old storage has no provenance: do not guess from last_fired/count.
+    store.update_reminder(rid, status="snoozed", snooze_until=now[0].isoformat(),
+                          last_fired="2026-06-01T12:00:00", snooze_count=12)
+    reminders.check_and_fire(store, config)
+    run.assert_called_once()

--- a/tests/test_reminder_auto_snooze.py
+++ b/tests/test_reminder_auto_snooze.py
@@ -190,3 +190,29 @@ def test_auto_snooze_does_not_reopen_concurrent_terminal_reminder(cycle, monkeyp
         run.assert_not_called()
     finally:
         other.close()
+
+
+def test_recurring_cleanup_preserves_concurrent_manual_resume(cycle, monkeypatch):
+    store, config, now, notify, run = cycle
+    rid = add_action(store)
+    store.update_reminder(rid, reminder_type="recurring", schedule="FREQ=HOURLY")
+    reminders.check_and_fire(store, config)  # stale recurrence becomes paused
+    assert store.get_reminder(rid)["extra"]["action_status"] == "paused"
+    now[0] += datetime.timedelta(hours=1)
+    reminders.snooze_reminder(store, rid, duration_seconds=1)
+    now[0] += datetime.timedelta(seconds=1)
+    other = Store(config)
+    try:
+        def resume_action():
+            assert actions.execute_action(other, other.get_reminder(rid), config,
+                                          manual=True)["status"] == "completed"
+
+        monkeypatch.setattr(store, "_conn", BeforeReminderWrite(store.conn, resume_action))
+        reminders.check_and_fire(store, config)
+        run.assert_called_once()  # the deliberate resume during advancement
+        now[0] += datetime.timedelta(hours=1)
+        reminders.check_and_fire(store, config)
+        assert run.call_count == 2  # the next occurrence must remain resumed
+        assert store.get_reminder(rid)["extra"]["action_status"] == "pending"
+    finally:
+        other.close()


### PR DESCRIPTION
Automatic snoozing could revive an action that the staleness guard had just rejected. For example, a June one-shot checked in September notifies and becomes `fired`; five minutes later it is automatically snoozed, and at snooze expiry `max(next_due, snooze_until)` makes the abandoned action look fresh enough to execute.

The July guard commit (`a6af9a9`) explicitly intends stale actions to notify only, while allowing deliberate long snoozes. Store the action's snooze deadline separately from automatic notification retries. Automatic snoozes preserve that deadline, deliberate snoozes renew it, and recurring advancement clears it for the next occurrence. This also prevents automatic retries from indefinitely refreshing a failed action.

Existing unmarked snoozes retain their prior semantics: the old records and activity log cannot distinguish manual from automatic snoozes, so this does not guess at historical intent or migrate an existing backlog. Newly logged snoozes record their origin. Snooze, action-result, and recurring advancement metadata updates serialize against the latest row, preserving completed action state and saved deadlines in either write ordering. Automatic retries recheck fired status under the write lock, so completed/cancelled rows are not reopened. Manual execution and recurring action parking/resumption policies remain unchanged. No live reminder data, configuration, or release changes are included.

Validation:

- Added disposable SQLite lifecycle tests with frozen June/September time, mocked notification delivery, mocked shell/Claude/Codex/OpenCode runners, and disabled scheduler repacking. They exercise stale check → fired → automatic snooze → expiry → check twice, deliberate manual execution, manual snooze after automatic snooze, bounded retries after a manual deferral, and legacy compatibility.
- Before implementation: **5 failed, 2 passed**. All four stale-action modes unexpectedly invoked their runners at automatic snooze expiry; the failed-action test observed a third execution after its deliberate deadline became stale. These were behavioral assertion failures against unchanged upstream code.
- Review-race regressions: **5 failed on eb67f64, all pass on 5eb38df**. Second-connection interleavings cover manual/automatic snooze versus action completion, action finishing after auto-snooze, and concurrent reminder completion/cancellation.
- Recurrence review regression: failed on 5eb38df (next occurrence remained paused after concurrent manual resume), passes on 0fedc2a. Advancement now reads and resets metadata under BEGIN IMMEDIATE.
- Latest head validation: **213 passed** across `test_reminder_auto_snooze.py`, `test_reminders.py`, `test_cron_reliability.py`, `test_scheduling.py`, and `test_store.py`.
- Full suite: **2,159 passed, 1 skipped, 1 failed**. The failure is `test_batch0_capture.py::test_r1_2_rerun_migrates_old_broken_entry_preserving_siblings` (`old --text entry survived the re-run migration`). Independently reproduced the same assertion on an untouched archive of upstream main `48285b8`; it is unrelated to this diff.
- Broad validation used temporary home resolution and a macOS sandbox denying host-home writes, network access, and launchctl/crontab execution.
- No PR-triggered test workflow exists upstream; the checked-in test workflow runs on release tags. Post-publication inspection confirms no Actions run for this branch; Adapt Review and Cursor Bugbot are the PR checks.

Latest operational validation: the immutable 0fedc2a wheel passed five actual launchd cycles in a disposable profile (stale action 0 executions; manual deferral 1; current action 1) and all 13 installed-wheel lifecycle/race tests. A separately authorized API follow-up completed exactly once through a guarded launchd/tmux adapter; global reminder actions remain disabled. Native `codex exec resume` started but its tools stalled and timed out, so native headless wake is not claimed validated. No operational artifacts or live data are part of this source PR. Latest Bugbot is green; a fresh Adapt re-review is still required before merge/release.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when reminder actions auto-run versus notify-only and adds transactional snooze/action updates; behavior is safety-critical but narrowly scoped and heavily tested.
> 
> **Overview**
> Fixes a bug where **automatic notification snoozes** could reset action “freshness” so reminders the staleness guard had already downgraded to **notify-only** would auto-execute again after snooze expiry.
> 
> Snooze handling now tracks a separate **`action_snooze_until`** in reminder `extra`: deliberate snoozes (`kin remind snooze`) set/extend that deadline; automatic retries preserve the existing deadline (or seed it once from legacy `snooze_until` without guessing provenance). **`_action_is_stale`** anchors overdue checks on `max(next_due, action_snooze_until)` instead of treating every snooze as a deliberate deferral. **Recurring advancement** clears `action_snooze_until` for the next occurrence and runs under a write lock so concurrent manual resumes are not overwritten.
> 
> **`Store.snooze_reminder`** gains an `automatic` flag, returns whether a row was updated, serializes snooze writes, and only auto-snoozes rows still in **`fired`** status. **`update_reminder_action`** updates action metadata without clobbering concurrent snooze deadlines. README documents **`max_action_overdue`** and the manual vs automatic snooze semantics. New lifecycle and concurrency tests cover stale one-shots, manual deferral, legacy rows, and races with completion/cancellation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0fedc2a372a352177d77cf30a199af744020dca5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
