### PR TITLE
fix(doctor): validate FTS integrity and keep repairs idempotent

### DIFF
--- a/.kin/doctor-fts-notes.md
+++ b/.kin/doctor-fts-notes.md
@@ -25,3 +25,9 @@ postings, equal-count swaps, stale text, full indexed fields and long content,
 trigger maintenance, transaction/lock cleanup, interruption, and repair rollback.
 The check scans the full index and canonical text and briefly requires a writer
 lock. It does not validate trigger definitions or change schema/search policy.
+
+The interruption fixture must keep its progress handler armed until the SQLite
+error propagates (verified on Python 3.12.2 / SQLite 3.45.1 and Python 3.13.7 /
+SQLite 3.50.4). Also assert no discarded-savepoint cleanup was attempted: an
+armed handler can interrupt that erroneous cleanup too, hiding a missing guard.
+Removing the transaction guard makes this regression fail on both combinations.

--- a/.kin/doctor-fts-notes.md
+++ b/.kin/doctor-fts-notes.md
@@ -31,3 +31,15 @@ error propagates (verified on Python 3.12.2 / SQLite 3.45.1 and Python 3.13.7 /
 SQLite 3.50.4). Also assert no discarded-savepoint cleanup was attempted: an
 armed handler can interrupt that erroneous cleanup too, hiding a missing guard.
 Removing the transaction guard makes this regression fail on both combinations.
+
+Doctor repairs integrity rather than enriching the graph. Low cross-domain
+bridging remains an advisory warning pointing to `kin dream`; `doctor --fix`
+no longer generates random bridge suggestions or counts them as repairs.
+After successful repair on a stable supported database, repeated `--fix`
+preserves durable logical state. This does not promise identical output or
+zero SQLite filesystem activity: the first report retains repair history,
+and integrity checks still use a rolled-back write transaction.
+
+Dream owns graph enrichment. Its current full mode stages bounded shared-domain
+proposals for review; it does not automatically improve disjoint-domain bridge
+density. More pending suggestions are not evidence of better graph connectivity.

--- a/.kin/doctor-fts-notes.md
+++ b/.kin/doctor-fts-notes.md
@@ -1,0 +1,27 @@
+# Doctor FTS integrity (issue #21)
+
+`nodes_fts` is an external-content FTS5 table backed by `nodes`. A plain
+`COUNT(*) FROM nodes_fts` counts the backing rows, not the indexed postings.
+Since v12, `Store.stats()["nodes"]` means semantic nodes and excludes sessions;
+comparing those counts both falsely flags healthy session history and misses
+real index corruption in semantic-only graphs.
+
+Doctor uses FTS5 `integrity-check` with `rank=1` to compare actual postings with
+all backing text. The index population remains all stored nodes, including
+sessions and retired nodes. Search still excludes archived/superseded results
+by default and restores them with `include_archived`.
+
+The check's INSERT syntax opens a write transaction, so its savepoint is rolled
+back and released without committing a caller's pending work. SQLite interrupts
+and some I/O errors can roll back the entire transaction themselves; cleanup
+must not mask the original error by referring to a discarded savepoint.
+A rebuild is checked again within the repair transaction before commit and
+before reporting `FIXED`. The repair invocation retains doctor's existing
+issue-history convention; the subsequent doctor invocation reports healthy.
+
+Regression coverage lives in `tests/test_doctor_fts.py` and
+`tests/test_doctor_fts_transactions.py`: mixed v12 populations, missing/extra
+postings, equal-count swaps, stale text, full indexed fields and long content,
+trigger maintenance, transaction/lock cleanup, interruption, and repair rollback.
+The check scans the full index and canonical text and briefly requires a writer
+lock. It does not validate trigger definitions or change schema/search policy.

--- a/src/kindex/cli.py
+++ b/src/kindex/cli.py
@@ -1462,38 +1462,8 @@ def cmd_doctor(args):
                 if cross_pct < 0.10:
                     warnings.append(
                         f"Low cross-domain bridging: {cross_domain}/{total_edges_g} edges "
-                        f"({cross_pct:.0%}) cross domain boundaries (< 10%)")
-                    if do_fix:
-                        # Suggest edges between nodes in different domains
-                        import random
-                        domain_nodes: dict[str, list[str]] = {}
-                        for nid, doms in domain_sets.items():
-                            for d in doms:
-                                domain_nodes.setdefault(d, []).append(nid)
-                        dom_list = list(domain_nodes.keys())
-                        suggested = 0
-                        for i in range(len(dom_list)):
-                            for j in range(i + 1, len(dom_list)):
-                                pool_a = domain_nodes[dom_list[i]]
-                                pool_b = domain_nodes[dom_list[j]]
-                                if pool_a and pool_b:
-                                    a = random.choice(pool_a)
-                                    b = random.choice(pool_b)
-                                    a_title = G.nodes[a].get("title", a)
-                                    b_title = G.nodes[b].get("title", b)
-                                    store.add_suggestion(
-                                        a_title, b_title,
-                                        reason=f"Cross-domain bridge: {dom_list[i]} <-> {dom_list[j]}",
-                                        source="doctor --fix",
-                                    )
-                                    suggested += 1
-                                    if suggested >= 5:
-                                        break
-                            if suggested >= 5:
-                                break
-                        if suggested:
-                            warnings[-1] += f" (suggested {suggested} bridge edges — see `kin suggest`)"
-                            fixes_applied += 1
+                        f"({cross_pct:.0%}) cross domain boundaries (< 10%) — "
+                        "run `kin dream` to discover connections")
 
     # ── Trailhead coverage ──
     if stats["nodes"] > 10 and stats["edges"] >= 4:

--- a/src/kindex/cli.py
+++ b/src/kindex/cli.py
@@ -6,6 +6,7 @@ import argparse
 import datetime
 import json
 import os
+import sqlite3
 import sys
 from pathlib import Path
 
@@ -1378,18 +1379,19 @@ def cmd_doctor(args):
 
     # ── FTS5 sync check ──
     try:
-        fts_count = store.conn.execute(
-            "SELECT COUNT(*) FROM nodes_fts").fetchone()[0]
-        node_count = stats["nodes"]
-        if fts_count != node_count:
-            issues.append(f"FTS5 index out of sync: {fts_count} indexed vs {node_count} nodes")
-            if do_fix:
-                store.conn.execute("INSERT INTO nodes_fts(nodes_fts) VALUES('rebuild')")
-                store.conn.commit()
+        store.check_fts_integrity()
+    except sqlite3.DatabaseError as exc:
+        issues.append(f"FTS5 index integrity check failed: {exc}")
+        if do_fix:
+            try:
+                with store.conn:
+                    store.conn.execute("INSERT INTO nodes_fts(nodes_fts) VALUES('rebuild')")
+                    store.check_fts_integrity()
+            except sqlite3.DatabaseError as repair_exc:
+                issues[-1] += f" (FIX FAILED: {repair_exc})"
+            else:
                 fixes_applied += 1
                 issues[-1] += " (FIXED: rebuilt FTS5)"
-    except Exception:
-        warnings.append("Could not check FTS5 index health")
 
     # ── Dangling edges ──
     dangling = store.conn.execute(

--- a/src/kindex/store.py
+++ b/src/kindex/store.py
@@ -3312,6 +3312,31 @@ class Store:
 
     # ── FTS5 search ────────────────────────────────────────────────────
 
+    def check_fts_integrity(self) -> None:
+        """Raise a SQLite error if the index disagrees with stored node text.
+
+        nodes_fts is an external-content table: ordinary reads (including
+        COUNT(*)) read nodes, not the indexed postings. rank=1 also checks
+        those postings against the complete external content population.
+
+        The check uses INSERT syntax, so isolate and roll it back to release
+        its write transaction without committing any caller's pending data.
+        """
+        conn = self.conn
+        conn.execute("SAVEPOINT check_fts_integrity")
+        try:
+            conn.execute(
+                "INSERT INTO nodes_fts(nodes_fts, rank) VALUES('integrity-check', 1)"
+            )
+        finally:
+            # Interrupts and some I/O errors roll back the whole transaction,
+            # removing the savepoint. Do not mask their original SQLite error.
+            if conn.in_transaction:
+                try:
+                    conn.execute("ROLLBACK TO check_fts_integrity")
+                finally:
+                    conn.execute("RELEASE check_fts_integrity")
+
     def fts_search(self, query: str, limit: int = 20,
                    include_archived: bool = False) -> list[dict]:
         """Full-text search using FTS5 BM25 ranking.

--- a/tests/test_doctor_fts.py
+++ b/tests/test_doctor_fts.py
@@ -1,0 +1,213 @@
+"""Doctor must validate actual FTS postings against all canonical v12 rows."""
+
+from contextlib import closing
+import json
+import os
+from pathlib import Path
+import sqlite3
+import subprocess
+import sys
+
+import pytest
+
+from kindex.config import Config
+from kindex.store import Store
+
+
+@pytest.fixture
+def graph(tmp_path, monkeypatch):
+    """An isolated connected graph; doctor runs in a separate CLI process."""
+    home = tmp_path / "home"
+    home.mkdir()
+    for name, path in {
+        "HOME": home,
+        "XDG_CONFIG_HOME": home / "config",
+        "XDG_DATA_HOME": home / "data",
+        "XDG_STATE_HOME": home / "state",
+        "XDG_CACHE_HOME": home / "cache",
+    }.items():
+        monkeypatch.setenv(name, str(path))
+    data_dir = tmp_path / "graph"
+    store = Store(Config(data_dir=str(data_dir)))
+    store.add_node("Alpha", "originalneedle canonical body", node_id="alpha")
+    store.add_node("Beta", "betaneedle canonical body", node_id="beta")
+    store.add_edge("alpha", "beta", bidirectional=True)
+    assert store.get_meta("schema_version") == "12"
+    db_path = store.db_path
+    store.close()
+
+    def doctor(*args):
+        # Whitelist the child environment: no ambient profiles, provider keys,
+        # project selection, reminder callbacks, or user config can leak in.
+        env = {name: os.environ[name] for name in (
+            "HOME", "XDG_CONFIG_HOME", "XDG_DATA_HOME", "XDG_STATE_HOME",
+            "XDG_CACHE_HOME", "PATH", "SYSTEMROOT",
+        ) if name in os.environ}
+        env["PYTHONPATH"] = str(Path(__file__).resolve().parents[1] / "src")
+        result = subprocess.run(
+            [sys.executable, "-m", "kindex.cli", "doctor", "--json",
+             "--data-dir", str(data_dir), *args],
+            cwd=tmp_path, env=env, capture_output=True, text=True, timeout=30,
+        )
+        assert result.returncode == 0, result.stderr
+        return json.loads(result.stdout)
+
+    return data_dir, db_path, doctor
+
+
+def fts_issues(report):
+    return [item for item in report["issues"] if "FTS5" in item]
+
+
+def matches(db_path, token):
+    with sqlite3.connect(db_path) as conn:
+        return {row[0] for row in conn.execute(
+            "SELECT rowid FROM nodes_fts WHERE nodes_fts MATCH ?", (token,))}
+
+
+def canonical_rows(db_path):
+    with sqlite3.connect(db_path) as conn:
+        return conn.execute("SELECT * FROM nodes ORDER BY id").fetchall()
+
+
+def test_v12_mixed_populations_do_not_request_rebuild(graph):
+    data_dir, db_path, doctor = graph
+    with closing(Store(Config(data_dir=str(data_dir)))) as store:
+        for node_id, node_type, status in [
+            ("session", "session", "active"),
+            ("ignored", "concept", "ignored"),
+            ("archived", "concept", "archived"),
+            ("superseded", "concept", "superseded"),
+            ("deprecated", "concept", "deprecated"),
+        ]:
+            store.add_node(node_id, f"{node_id}needle body", node_id=node_id,
+                           node_type=node_type, status=status)
+            store.add_edge("alpha", node_id, bidirectional=True)
+    before = canonical_rows(db_path)
+    for report in (doctor(), doctor("--fix"), doctor()):
+        assert not fts_issues(report), report
+        assert report["healthy"], report
+        assert report["fixes_applied"] == 0
+    assert canonical_rows(db_path) == before
+    for token in ("sessionneedle", "ignoredneedle", "archivedneedle",
+                  "supersededneedle", "deprecatedneedle"):
+        assert len(matches(db_path, token)) == 1
+
+
+@pytest.mark.parametrize("mixed", [False, True], ids=["semantic", "mixed"])
+@pytest.mark.parametrize("damage", ["missing", "extra", "equal_count_swap", "stale_text"])
+def test_doctor_detects_and_repairs_postings_corruption(graph, damage, mixed):
+    data_dir, db_path, doctor = graph
+    if mixed:
+        with closing(Store(Config(data_dir=str(data_dir)))) as store:
+            store.add_node("Session", "sessionneedle body", node_id="session",
+                           node_type="session")
+    assert doctor()["healthy"]
+    before = canonical_rows(db_path)
+    with sqlite3.connect(db_path) as conn:
+        row = conn.execute(
+            "SELECT rowid, id, title, content, aka, intent, domains "
+            "FROM nodes WHERE id='alpha'"
+        ).fetchone()
+        if damage in ("missing", "equal_count_swap", "stale_text"):
+            conn.execute(
+                "INSERT INTO nodes_fts(nodes_fts,rowid,id,title,content,aka,intent,domains) "
+                "VALUES('delete',?,?,?,?,?,?,?)", row,
+            )
+        if damage in ("extra", "equal_count_swap"):
+            conn.execute(
+                "INSERT INTO nodes_fts(rowid,id,title,content,aka,intent,domains) "
+                "VALUES(999999,'ghost','Ghost','ghostneedle','','','')"
+            )
+        if damage == "stale_text":
+            stale = list(row)
+            stale[3] = "staleneedle obsolete body"
+            conn.execute(
+                "INSERT INTO nodes_fts(rowid,id,title,content,aka,intent,domains) "
+                "VALUES(?,?,?,?,?,?,?)", stale,
+            )
+        # External-content COUNT reads the canonical table, even when actual
+        # posting membership is missing, extra, swapped, or text is stale.
+        assert conn.execute("SELECT COUNT(*) FROM nodes_fts").fetchone()[0] == (3 if mixed else 2)
+    if damage != "extra":
+        assert not matches(db_path, "originalneedle")
+    if damage in ("extra", "equal_count_swap"):
+        assert matches(db_path, "ghostneedle") == {999999}
+    report = doctor()
+    assert fts_issues(report), report
+    assert not report["healthy"]
+    assert canonical_rows(db_path) == before
+    repaired = doctor("--fix")
+    assert repaired["fixes_applied"] == 1, repaired
+    assert any("FIXED" in issue for issue in fts_issues(repaired)), repaired
+    after = doctor()
+    assert after["healthy"], after
+    assert not fts_issues(after)
+    assert matches(db_path, "originalneedle") == {row[0]}
+    assert not matches(db_path, "ghostneedle")
+    assert not matches(db_path, "staleneedle")
+    assert canonical_rows(db_path) == before
+
+
+def test_fts_triggers_keep_updates_and_deletes_healthy(graph):
+    _, db_path, doctor = graph
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("UPDATE nodes SET content='replacementneedle body' WHERE id='alpha'")
+    assert not matches(db_path, "originalneedle")
+    assert matches(db_path, "replacementneedle")
+    assert not fts_issues(doctor())
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("DELETE FROM edges WHERE from_id='alpha' OR to_id='alpha'")
+        conn.execute("DELETE FROM nodes WHERE id='alpha'")
+    assert not matches(db_path, "replacementneedle")
+    assert not fts_issues(doctor())
+
+
+def test_rebuild_restores_mixed_rows_and_full_indexed_content(graph):
+    data_dir, db_path, doctor = graph
+    long_body = "canonical body " * 800 + "longtailneedle"
+    with closing(Store(Config(data_dir=str(data_dir)))) as store:
+        store.add_node(
+            "titleneedle", long_body, node_id="history", node_type="session",
+            status="archived", aka=["aliasneedle"], intent="intentneedle",
+            domains=["domainneedle"],
+        )
+    def search_scope():
+        with closing(Store(Config(data_dir=str(data_dir)))) as store:
+            return (
+                {node["id"] for node in store.fts_search("longtailneedle")},
+                {node["id"] for node in store.fts_search(
+                    "longtailneedle", include_archived=True)},
+            )
+
+    assert search_scope() == (set(), {"history"})
+    before = canonical_rows(db_path)
+    with sqlite3.connect(db_path) as conn:
+        rowid = conn.execute("SELECT rowid FROM nodes WHERE id='history'").fetchone()[0]
+        conn.execute("INSERT INTO nodes_fts(nodes_fts) VALUES('delete-all')")
+    assert not matches(db_path, "longtailneedle")
+    assert fts_issues(doctor())
+    repaired = doctor("--fix")
+    assert repaired["fixes_applied"] == 1, repaired
+    assert doctor()["healthy"]
+    for token in ("titleneedle", "longtailneedle", "aliasneedle",
+                  "intentneedle", "domainneedle"):
+        assert matches(db_path, token) == {rowid}
+    assert matches(db_path, "originalneedle")
+    assert matches(db_path, "betaneedle")
+    assert canonical_rows(db_path) == before
+    assert search_scope() == (set(), {"history"})
+
+
+def test_unavailable_index_stays_unhealthy_when_repair_fails(graph):
+    _, db_path, doctor = graph
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("DROP TABLE nodes_fts")
+    for args in ((), ("--fix",), ()):
+        report = doctor(*args)
+        assert not report["healthy"]
+        assert fts_issues(report)
+        assert report["fixes_applied"] == 0
+        assert not any("FIXED" in issue for issue in fts_issues(report))
+        if args:
+            assert any("FIX FAILED" in issue for issue in fts_issues(report))

--- a/tests/test_doctor_fts_transactions.py
+++ b/tests/test_doctor_fts_transactions.py
@@ -69,6 +69,8 @@ def test_failed_post_rebuild_validation_rolls_back_and_reports_failure(store, mo
 
     monkeypatch.setattr(store, "check_fts_integrity", check)
     monkeypatch.setattr(cli, "_store", lambda args: store)
+    monkeypatch.setenv("KIN_PROFILE", "unregistered-doctor-test-profile")
+    monkeypatch.setattr(cli, "_config", lambda args: store.config)
     args = argparse.Namespace(json=True, fix=True, data_dir=str(store.db_path.parent))
     cli.cmd_doctor(args)
     report = json.loads(capsys.readouterr().out)

--- a/tests/test_doctor_fts_transactions.py
+++ b/tests/test_doctor_fts_transactions.py
@@ -1,0 +1,102 @@
+"""FTS diagnostics must release locks and never report an unverified repair."""
+
+import argparse
+import json
+import sqlite3
+
+import pytest
+
+from kindex import cli
+from kindex.config import Config
+from kindex.store import Store
+
+
+@pytest.fixture
+def store(tmp_path):
+    value = Store(Config(data_dir=str(tmp_path)))
+    value.add_node("Alpha", "originalneedle", node_id="alpha")
+    value.add_node("Beta", "betaneedle", node_id="beta")
+    value.add_edge("alpha", "beta", bidirectional=True)
+    yield value
+    value.close()
+
+
+def remove_postings(store):
+    store.conn.execute("INSERT INTO nodes_fts(nodes_fts) VALUES('delete-all')")
+    store.conn.commit()
+
+
+@pytest.mark.parametrize("corrupt", [False, True])
+def test_integrity_check_preserves_pending_transaction(store, corrupt):
+    if corrupt:
+        remove_postings(store)
+    store.conn.execute("INSERT INTO meta(key,value) VALUES('pending-test','yes')")
+    if corrupt:
+        with pytest.raises(sqlite3.DatabaseError):
+            store.check_fts_integrity()
+    else:
+        store.check_fts_integrity()
+    assert store.conn.in_transaction
+    assert store.get_meta("pending-test") == "yes"
+    store.conn.rollback()
+    assert store.get_meta("pending-test") is None
+
+
+@pytest.mark.parametrize("corrupt", [False, True])
+def test_integrity_check_releases_writer_lock(store, corrupt):
+    if corrupt:
+        remove_postings(store)
+        with pytest.raises(sqlite3.DatabaseError):
+            store.check_fts_integrity()
+    else:
+        store.check_fts_integrity()
+    assert not store.conn.in_transaction
+    with sqlite3.connect(store.db_path, timeout=0) as other:
+        other.execute("INSERT INTO meta(key,value) VALUES('another-writer','yes')")
+
+
+def test_failed_post_rebuild_validation_rolls_back_and_reports_failure(store, monkeypatch, capsys):
+    remove_postings(store)
+    real_check = store.check_fts_integrity
+    calls = 0
+
+    def check():
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            raise sqlite3.DatabaseError("injected post-rebuild integrity failure")
+        return real_check()
+
+    monkeypatch.setattr(store, "check_fts_integrity", check)
+    monkeypatch.setattr(cli, "_store", lambda args: store)
+    args = argparse.Namespace(json=True, fix=True, data_dir=str(store.db_path.parent))
+    cli.cmd_doctor(args)
+    report = json.loads(capsys.readouterr().out)
+    assert calls == 2
+    assert not report["healthy"]
+    assert report["fixes_applied"] == 0
+    assert any("FIX FAILED" in issue for issue in report["issues"])
+    assert not any("FIXED" in issue for issue in report["issues"])
+    with sqlite3.connect(store.db_path) as conn:
+        assert conn.execute(
+            "SELECT rowid FROM nodes_fts WHERE nodes_fts MATCH 'originalneedle'"
+        ).fetchall() == []
+
+
+def test_interrupted_check_preserves_original_sqlite_error(store):
+    def interrupt_once():
+        store.conn.set_progress_handler(None, 0)
+        return 1
+
+    def trace(statement):
+        if "VALUES('integrity-check', 1)" in statement:
+            store.conn.set_progress_handler(interrupt_once, 1)
+
+    store.conn.set_trace_callback(trace)
+    try:
+        with pytest.raises(sqlite3.OperationalError, match="interrupted"):
+            store.check_fts_integrity()
+    finally:
+        store.conn.set_trace_callback(None)
+        store.conn.set_progress_handler(None, 0)
+    assert not store.conn.in_transaction

--- a/tests/test_doctor_fts_transactions.py
+++ b/tests/test_doctor_fts_transactions.py
@@ -84,13 +84,14 @@ def test_failed_post_rebuild_validation_rolls_back_and_reports_failure(store, mo
 
 
 def test_interrupted_check_preserves_original_sqlite_error(store):
-    def interrupt_once():
-        store.conn.set_progress_handler(None, 0)
-        return 1
+    statements = []
 
     def trace(statement):
+        statements.append(statement)
         if "VALUES('integrity-check', 1)" in statement:
-            store.conn.set_progress_handler(interrupt_once, 1)
+            # Older SQLite versions need the handler to remain armed until
+            # the interruption propagates out of the FTS virtual table.
+            store.conn.set_progress_handler(lambda: 1, 1)
 
     store.conn.set_trace_callback(trace)
     try:
@@ -100,3 +101,6 @@ def test_interrupted_check_preserves_original_sqlite_error(store):
         store.conn.set_trace_callback(None)
         store.conn.set_progress_handler(None, 0)
     assert not store.conn.in_transaction
+    # A still-armed handler can also interrupt erroneous cleanup, hiding the
+    # missing-savepoint regression behind another "interrupted" exception.
+    assert not any(sql.startswith(("ROLLBACK TO", "RELEASE")) for sql in statements)

--- a/tests/test_doctor_idempotence.py
+++ b/tests/test_doctor_idempotence.py
@@ -1,0 +1,133 @@
+"""Doctor repairs integrity; graph enrichment remains an advisory workflow."""
+
+from contextlib import closing
+import itertools
+import json
+import os
+from pathlib import Path
+import sqlite3
+import subprocess
+import sys
+
+import pytest
+
+from kindex.config import Config
+from kindex.store import Store
+
+
+@pytest.fixture
+def low_bridge_graph(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    isolated = {
+        "HOME": home,
+        "XDG_CONFIG_HOME": home / "config",
+        "XDG_DATA_HOME": home / "data",
+        "XDG_STATE_HOME": home / "state",
+        "XDG_CACHE_HOME": home / "cache",
+    }
+    for name, path in isolated.items():
+        path.mkdir(parents=True, exist_ok=True)
+        monkeypatch.setenv(name, str(path))
+    data_dir = tmp_path / "graph"
+    config_path = home / "config" / "doctor.json"
+    config_path.write_text(json.dumps({
+        "data_dir": str(data_dir),
+        "profiles": {},
+        "reminders": {"action_enabled": False},
+    }))
+    with closing(Store(Config(data_dir=str(data_dir)))) as store:
+        # Two complete four-node domains joined by one bidirectional edge:
+        # connected, no orphans, and only 2/26 directed edges cross domains.
+        for domain in ("alpha", "beta"):
+            ids = [f"{domain}-{i}" for i in range(4)]
+            for node_id in ids:
+                store.add_node(
+                    node_id, f"canonicalneedle knowledge about {node_id}",
+                    node_id=node_id, domains=[domain],
+                )
+            for left, right in itertools.combinations(ids, 2):
+                store.add_edge(left, right, bidirectional=True)
+        store.add_edge("alpha-0", "beta-0", bidirectional=True)
+        db_path = store.db_path
+
+    def doctor(*args):
+        env = {name: str(path) for name, path in isolated.items()}
+        for name in ("PATH", "SYSTEMROOT"):
+            if name in os.environ:
+                env[name] = os.environ[name]
+        env["PYTHONPATH"] = str(Path(__file__).resolve().parents[1] / "src")
+        result = subprocess.run(
+            [sys.executable, "-m", "kindex.cli", "doctor", "--json",
+             "--config", str(config_path), "--data-dir", str(data_dir), *args],
+            cwd=tmp_path, env=env, capture_output=True, text=True, timeout=30,
+        )
+        assert result.returncode == 0, result.stderr
+        return json.loads(result.stdout)
+
+    return db_path, doctor
+
+
+def persisted_state(db_path):
+    with sqlite3.connect(db_path) as conn:
+        return {
+            table: conn.execute(f"SELECT * FROM {table} ORDER BY id").fetchall()
+            for table in ("nodes", "edges", "suggestions", "activity_log")
+        }
+
+
+def assert_bridge_advisory(report):
+    warnings = [text for text in report["warnings"]
+                if "cross-domain" in text.lower()]
+    assert warnings, report
+    assert any("dream" in text.lower() for text in warnings), warnings
+    assert not any("cross-domain" in text.lower() for text in report["issues"])
+
+
+def test_repeated_fix_leaves_low_bridge_graph_unchanged(low_bridge_graph):
+    db_path, doctor = low_bridge_graph
+    before = persisted_state(db_path)
+    initial = doctor()
+    assert initial["healthy"], initial
+    assert persisted_state(db_path) == before
+
+    for _ in range(2):
+        report = doctor("--fix")
+        # Assert actual durable effects before checking reported fix counts:
+        # the old random bridge suggestion behavior violates this invariant.
+        assert persisted_state(db_path) == before
+        assert report["healthy"], report
+        assert report["fixes_applied"] == 0, report
+        assert_bridge_advisory(report)
+    assert_bridge_advisory(initial)
+
+
+def test_fts_repair_runs_once_without_enrichment_side_effects(low_bridge_graph):
+    db_path, doctor = low_bridge_graph
+    before = persisted_state(db_path)
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("INSERT INTO nodes_fts(nodes_fts) VALUES('delete-all')")
+        assert not conn.execute(
+            "SELECT rowid FROM nodes_fts WHERE nodes_fts MATCH 'canonicalneedle'"
+        ).fetchall()
+
+    damaged = doctor()
+    assert not damaged["healthy"], damaged
+    assert any("FTS5" in text for text in damaged["issues"]), damaged
+    assert persisted_state(db_path) == before
+
+    repaired = doctor("--fix")
+    assert persisted_state(db_path) == before
+    assert repaired["fixes_applied"] == 1, repaired
+    assert any("FTS5" in text and "FIXED" in text
+               for text in repaired["issues"]), repaired
+    assert_bridge_advisory(repaired)
+    with sqlite3.connect(db_path) as conn:
+        assert len(conn.execute(
+            "SELECT rowid FROM nodes_fts WHERE nodes_fts MATCH 'canonicalneedle'"
+        ).fetchall()) == 8
+
+    second = doctor("--fix")
+    assert second["healthy"], second
+    assert second["fixes_applied"] == 0, second
+    assert persisted_state(db_path) == before
+    assert_bridge_advisory(second)


### PR DESCRIPTION
Fixes #21.

Doctor compared external-content FTS row counts with semantic node counts, so session-bearing v12 graphs stayed unhealthy after rebuilding. Those counts also cannot detect missing, extra or stale postings. Validate FTS5 postings against all canonical text with rank=1, rebuild and verify atomically, and release diagnostic savepoints without committing caller work. Preserve full text, schema, triggers and search scope.

Keep `doctor --fix` focused on integrity repair: remove random cross-domain suggestion generation and its repair count. Low bridge density remains advisory and points to `kin dream`. Repeated successful repairs preserve durable logical state; output can still retain the first invocation’s repair history. Graph enrichment remains Dream’s responsibility.

### Validation

- Two new isolated CLI regressions fail on the prior head due to durable suggestion/activity writes and pass after the change. Healthy repeated fixes write nothing; damaged FTS repairs once, then reports zero fixes.
- 26 doctor/FTS tests pass. The rollback test now explicitly isolates `cli._config`; the ambient unknown-profile failure was reproduced before the fix, and all six transaction tests pass with that profile present afterward.
- Combined current-main validation: **2,186 passed, 1 skipped** on immutable main 45cc876 plus the complete PR delta, under isolated HOME/config and network/scheduler denial. The earlier prior-base run had 2,180 passed, 1 skipped and the known hook-migration fixture failure; that failure was independently reproduced on 8fe3225 and is fixed by the separate upstream PR25. Full pytest also passed in [GitHub CI](https://github.com/wandercom/kindex/actions/runs/34654998094/job/103445348997) on f346ae0; Cursor Bugbot passed on the same head.
- Protected SQLite online backup of the populated v12 datastore (over 9,000 nodes), using a read-only source transaction including WAL state. Candidate commands used isolated clones/config/HOME, denied live graph access and network, and preserved pristine snapshots. Earlier corruption, equal-count membership, stale text, search-scope, migration, interruption and rollback probes passed.
- Latest real-data comparison: old doctor adds five suggestions per run; focused doctor changes no logical table on repeated runs. Full Dream stages 50 bounded shared-domain proposals but adds no edges or merges in this corpus. Connectivity is unchanged: more queued proposals are not claimed as better graph connectivity. Nodes’ canonical text, edges, vectors, reminders and schema are preserved; Dream changes only access metadata among node fields.
- Independent review found no blocking regression in the doctor refinement. No live datastore repair, background/reminder action, model request, installation, merge or release was performed by validation.

### Operational limits

FTS integrity checking scans full canonical text and briefly needs a writer lock. On the populated snapshot the check took ~0.20 s and rebuild/verify/commit ~0.56 s; full doctor graph analysis took ~18–21 s. Lock contention reports an inconclusive database-is-locked issue. These are local samples, not production latency bounds. Dream proposals still require review and its shared-domain proposals do not directly improve disjoint-domain bridge density.

Durable behavior notes are in `.kin/doctor-fts-notes.md`. PR #22’s separate transfer branch is untouched.
