### PR TITLE
fix: prepare 0.36.2 with hook migration and reusable CI

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "kindex",
   "description": "Every agent is smart inside its own silo. Kindex lets them work together: a persistent knowledge graph that Claude Code, Codex, Gemini CLI, Antigravity, OpenCode, and Cursor all read and write.",
-  "version": "0.36.0",
+  "version": "0.36.2",
   "author": {
     "name": "Wander",
     "url": "https://github.com/wandercom"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - run: pip install -e ".[dev,mcp]"
+      - run: pytest

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,9 +1,15 @@
-name: Publish to PyPI
+name: CI and Publish to PyPI
 
 on:
+  pull_request:
   push:
+    branches:
+      - main
     tags:
       - "v*"
+
+permissions:
+  contents: read
 
 jobs:
   test:
@@ -17,6 +23,7 @@ jobs:
       - run: pytest
 
   build:
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     needs: test
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,10 +1,7 @@
-name: CI and Publish to PyPI
+name: Publish to PyPI
 
 on:
-  pull_request:
   push:
-    branches:
-      - main
     tags:
       - "v*"
 
@@ -12,19 +9,11 @@ permissions:
   contents: read
 
 jobs:
-  test:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
-        with:
-          python-version: "3.12"
-      - run: pip install -e ".[dev,mcp]"
-      - run: pytest
+  ci:
+    uses: ./.github/workflows/ci.yml
 
   build:
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
-    needs: test
+    needs: ci
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/.kin/release-ci-notes.md
+++ b/.kin/release-ci-notes.md
@@ -13,10 +13,12 @@ ending in `/kin`. Commands from other locations require the installer's recorded
 ownership or explicit retirement. Foreign siblings and their entry metadata
 must survive migration.
 
-The same workflow test job now runs full pytest with Python 3.12 and
-`.[dev,mcp]` on pull requests, main pushes, and release tags. Only tag pushes
-can build, and publication depends on the tested build. Keep these events on
-one job so PR validation cannot drift from the release gate.
+The `CI` workflow in `.github/workflows/ci.yml` owns the full pytest job with
+Python 3.12 and `.[dev,mcp]`. It runs on pull requests and main pushes and supports
+manual dispatch and reusable calls. `Publish to PyPI` in `workflow.yml` triggers
+only on `v*` tags and invokes that same CI workflow before build and publication.
+Keep the test implementation in CI so PR validation cannot drift from release
+validation or appear to publish a package.
 
 On 2026-09-10, main had no branch protection and the repository had no rulesets.
 Running the PR check does not itself make passing tests mandatory for merging;

--- a/.kin/release-ci-notes.md
+++ b/.kin/release-ci-notes.md
@@ -1,0 +1,21 @@
+# Release test parity and historical Claude hook migration
+
+Release run 34538578659 for v0.36.1 failed the existing Stop-hook migration
+regression: `test_r1_2_rerun_migrates_old_broken_entry_preserving_siblings`.
+PR #23 had disclosed the same failure on unchanged main, but the test workflow
+only triggered on release tags. Automated PR review did not enforce pytest.
+
+Claude settings can retain a different absolute `kin` executable path after
+moving installations or machines. Historical ownership recognition must account
+for that path while still matching the entire known command template. A path
+or a Kindex-looking substring alone is not permission to remove a handler.
+Foreign siblings and their entry metadata must survive migration.
+
+The same workflow test job now runs full pytest with Python 3.12 and
+`.[dev,mcp]` on pull requests, main pushes, and release tags. Only tag pushes
+can build, and publication depends on the tested build. Keep these events on
+one job so PR validation cannot drift from the release gate.
+
+On 2026-09-10, main had no branch protection and the repository had no rulesets.
+Running the PR check does not itself make passing tests mandatory for merging;
+that requires making `test` a required check in repository settings.

--- a/.kin/release-ci-notes.md
+++ b/.kin/release-ci-notes.md
@@ -21,3 +21,8 @@ one job so PR validation cannot drift from the release gate.
 On 2026-09-10, main had no branch protection and the repository had no rulesets.
 Running the PR check does not itself make passing tests mandatory for merging;
 that requires making `test` a required check in repository settings.
+
+The next prepared package version is `0.36.2`. Keep pyproject, runtime version,
+both Claude plugin manifests, MCP registry metadata, server card, public badges,
+and changelog aligned. The failed `v0.36.1` tag contains `0.36.0` metadata and
+must not be reused or moved.

--- a/.kin/release-ci-notes.md
+++ b/.kin/release-ci-notes.md
@@ -5,11 +5,13 @@ regression: `test_r1_2_rerun_migrates_old_broken_entry_preserving_siblings`.
 PR #23 had disclosed the same failure on unchanged main, but the test workflow
 only triggered on release tags. Automated PR review did not enforce pytest.
 
-Claude settings can retain a different absolute `kin` executable path after
-moving installations or machines. Historical ownership recognition must account
-for that path while still matching the entire known command template. A path
-or a Kindex-looking substring alone is not permission to remove a handler.
-Foreign siblings and their entry metadata must survive migration.
+Claude settings can retain an old `kin` executable path. Support historical
+locations explicitly: `/opt/homebrew/bin/kin` and `/usr/local/bin/kin`, alongside
+bare `kin` and the current executable. Still require the entire known command
+template to match. Never discover owned binaries by searching settings for paths
+ending in `/kin`. Commands from other locations require the installer's recorded
+ownership or explicit retirement. Foreign siblings and their entry metadata
+must survive migration.
 
 The same workflow test job now runs full pytest with Python 3.12 and
 `.[dev,mcp]` on pull requests, main pushes, and release tags. Only tag pushes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to Kindex are documented here. Format follows [Keep a Change
 
 ## [Unreleased]
 
+## [0.36.2] - 2026-09-10
+
 ### Added
 - Optional Claude function-hook adapter, qualified against 2.1.263, with repo-local
   task routing, contextual retrieval, quarantined turn capture and visible owner
@@ -21,6 +23,12 @@ All notable changes to Kindex are documented here. Format follows [Keep a Change
   Personal fallback or unsigned Company authority.
 
 ### Fixed
+- Legacy Claude hooks migrate from explicitly supported prior executable locations
+  while preserving custom commands.
+- Full pytest validation runs on pull requests and main pushes using the same job
+  that gates release builds and PyPI publication.
+- Automatic reminder snoozes preserve the action execution cutoff, preventing
+  stale actions from being revived by notification retries.
 - Claude advisory context no longer emits a permission auto-allow.
 - Shared credential sanitizer protects Kindex-owned persistence, logging, export,
   candidate, model and embedding boundaries without entropy-based destruction of
@@ -30,8 +38,7 @@ All notable changes to Kindex are documented here. Format follows [Keep a Change
 - Hook installation tracks exact owned commands, preserves foreign siblings,
   reports unknown wrappers, backs up settings and uses correct Claude timeout units.
 
-See [function-hook boundaries and migration](docs/claude-function-hooks.md). A public
-major release is not cut by this development change.
+See [function-hook boundaries and migration](docs/claude-function-hooks.md).
 
 ## [0.36.0] - 2026-09-02
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,10 +17,10 @@ pytest tests/test_store.py -v
 pytest tests/ --cov=kindex --cov-report=term-missing
 ```
 
-GitHub Actions runs the full `pytest` suite on every pull request, pushes to
-`main`, and `v*` release tags using the same Python 3.12 job and `.[dev,mcp]`
-dependencies. Release builds and PyPI publishing require that job to pass;
-non-tag runs only execute tests. The `test` check must be required in branch
+The `CI` workflow runs full `pytest` with Python 3.12 and `.[dev,mcp]` on pull
+requests and pushes to `main`. It also supports manual dispatch and reusable
+workflow calls. `Publish to PyPI` runs only on `v*` tag pushes and invokes `CI`
+before building and publishing. The `test` check must be required in branch
 protection to prevent merging a failing suite.
 
 ## Key File Locations

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,12 @@ pytest tests/test_store.py -v
 pytest tests/ --cov=kindex --cov-report=term-missing
 ```
 
+GitHub Actions runs the full `pytest` suite on every pull request, pushes to
+`main`, and `v*` release tags using the same Python 3.12 job and `.[dev,mcp]`
+dependencies. Release builds and PyPI publishing require that job to pass;
+non-tag runs only execute tests. The `test` check must be required in branch
+protection to prevent merging a failing suite.
+
 ## Key File Locations
 
 | Path | Purpose |

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![v0.36.2](https://img.shields.io/badge/version-0.36.2-purple.svg)](https://github.com/wandercom/kindex/releases)
 [![PyPI](https://img.shields.io/pypi/v/kindex.svg)](https://pypi.org/project/kindex/)
 [![MCP Market](https://img.shields.io/badge/MCP%20Market-kindex-blue.svg)](https://mcpmarket.com/server/kindex)
-[![Tests](https://github.com/wandercom/kindex/actions/workflows/workflow.yml/badge.svg)](https://github.com/wandercom/kindex/actions/workflows/workflow.yml)
+[![Tests](https://github.com/wandercom/kindex/actions/workflows/ci.yml/badge.svg)](https://github.com/wandercom/kindex/actions/workflows/ci.yml)
 [![MCP Plugin](https://img.shields.io/badge/MCP-Plugin-orange.svg)](#install-as-agent-mcp-plugin)
 
 **Every agent is smart inside its own silo. Kindex lets them work together.**

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
 [![MIT License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
-[![v0.36.0](https://img.shields.io/badge/version-0.36.0-purple.svg)](https://github.com/wandercom/kindex/releases)
+[![v0.36.2](https://img.shields.io/badge/version-0.36.2-purple.svg)](https://github.com/wandercom/kindex/releases)
 [![PyPI](https://img.shields.io/pypi/v/kindex.svg)](https://pypi.org/project/kindex/)
 [![MCP Market](https://img.shields.io/badge/MCP%20Market-kindex-blue.svg)](https://mcpmarket.com/server/kindex)
 [![Tests](https://github.com/wandercom/kindex/actions/workflows/workflow.yml/badge.svg)](https://github.com/wandercom/kindex/actions/workflows/workflow.yml)

--- a/docs/.well-known/mcp/server-card.json
+++ b/docs/.well-known/mcp/server-card.json
@@ -2,7 +2,7 @@
   "$schema": "https://modelcontextprotocol.io/schemas/server-card.json",
   "serverInfo": {
     "name": "kindex",
-    "version": "0.36.0",
+    "version": "0.36.2",
     "title": "Kindex",
     "description": "Persistent knowledge graph for Claude Code, Codex, Gemini CLI, Google Antigravity, OpenCode, Cursor, and other AI-assisted workflows. Quarantined automatic capture, explicit verification and invalidation, trusted-only retrieval, bounded trusted resume, hybrid FTS5 + graph retrieval, operational guardrails, reminders, and git-tracked .kin project context.",
     "homepage": "https://kindex.tools",

--- a/docs/index.html
+++ b/docs/index.html
@@ -266,7 +266,7 @@
       </div>
     </div>
     <div class="badges">
-      <span class="badge green">v0.36.0</span>
+      <span class="badge green">v0.36.2</span>
       <span class="badge orange">MCP Plugin</span>
       <span class="badge blue">65 MCP Tools</span>
       <span class="badge purple">80+ CLI Commands</span>
@@ -828,7 +828,7 @@ work_policy:
       MIT License &middot;
       Free
     </p>
-    <p style="margin-top: 8px;">v0.36.0 &middot; MCP Plugin &middot; 65 MCP Tools &middot; 80+ CLI Commands &middot; CI Verified</p>
+    <p style="margin-top: 8px;">v0.36.2 &middot; MCP Plugin &middot; 65 MCP Tools &middot; 80+ CLI Commands &middot; CI Verified</p>
     <p style="margin-top: 8px;">A <a href="https://github.com/wandercom">Wander</a> project. &copy; 2026 Wander. MIT License.</p>
     <p style="margin-top: 8px;">
       <a href="https://kindex.tools">kindex.tools</a> &middot;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kindex"
-version = "0.36.0"
+version = "0.36.2"
 description = "Every agent is smart inside its own silo. Kindex lets them work together: a local-first knowledge graph and MCP server shared by Claude Code, Codex, Gemini CLI, Antigravity, OpenCode, and Cursor."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.jmcentire/kindex",
   "title": "Kindex",
   "description": "Persistent knowledge graph and MCP server for AI workflows with git-tracked project context.",
-  "version": "0.36.0",
+  "version": "0.36.2",
   "repository": {
     "url": "https://github.com/wandercom/kindex",
     "source": "github"
@@ -13,7 +13,7 @@
     {
       "registryType": "pypi",
       "identifier": "kindex",
-      "version": "0.36.0",
+      "version": "0.36.2",
       "runtimeHint": "pipx",
       "transport": {
         "type": "stdio"

--- a/src/kindex/__init__.py
+++ b/src/kindex/__init__.py
@@ -1,3 +1,3 @@
 """Kindex — Knowledge graph that learns from your conversations."""
 
-__version__ = "0.36.0"
+__version__ = "0.36.2"

--- a/src/kindex/claude_install.py
+++ b/src/kindex/claude_install.py
@@ -59,7 +59,36 @@ def legacy_manifest(config, kin_path: str) -> dict:
     return {event: [{"matcher": "", "hooks": handlers}] for event, handlers in items.items()}
 
 
-def _known_commands(config, kin_path):
+def _historical_kin_paths(data: dict) -> set[str]:
+    """Find candidate old executable paths without treating them as ownership.
+
+    An installation may have moved (or its settings may come from another
+    machine). Decode shell quoting only; the complete command must still match
+    a generated historical template before it can be removed.
+    """
+    paths = set()
+    for entries in data.get("hooks", {}).values():
+        for entry in entries:
+            if not isinstance(entry, dict) or not isinstance(entry.get("hooks"), list):
+                continue
+            for handler in entry["hooks"]:
+                if not isinstance(handler, dict) or handler.get("type") != "command":
+                    continue
+                command = handler.get("command")
+                if not isinstance(command, str):
+                    continue
+                try:
+                    parts = shlex.split(command)
+                    if len(parts) == 3 and parts[:2] == ["/bin/bash", "-lc"]:
+                        parts = shlex.split(parts[2])
+                except ValueError:
+                    continue
+                paths.update(part for part in parts
+                             if Path(part).is_absolute() and Path(part).name == "kin")
+    return paths
+
+
+def _known_commands(config, kin_path, historical_paths=()):
     from .setup import _kin_hook_command, _kin_stop_hook_command
     commands = {h["command"] for entries in legacy_manifest(config, kin_path).values()
                 for entry in entries for h in entry["hooks"]}
@@ -72,7 +101,7 @@ def _known_commands(config, kin_path):
                   "attention reinforce --enqueue", "dream --detach --lightweight",
                   'compact-hook --text "Session ended"']
     for args in historical:
-        for binary in dict.fromkeys(["kin", kin_path]):
+        for binary in dict.fromkeys(["kin", kin_path, *historical_paths]):
             commands.add(f"{binary} {args}")
             commands.add(_kin_hook_command(binary, shlex.split(args)))
             commands.add(_kin_stop_hook_command(binary, shlex.split(args)))
@@ -129,7 +158,8 @@ def install(config, *, mode="legacy", dry_run=False, uninstall=False,
     original_data = json.loads(json.dumps(data))
     record = json.loads(record_path.read_text()) if record_path.exists() else {}
     kin_path = _find_kin_path()
-    commands = _known_commands(config, kin_path) | set(record.get("commands", [])) | set(retire_commands or [])
+    commands = (_known_commands(config, kin_path, _historical_kin_paths(data))
+                | set(record.get("commands", [])) | set(retire_commands or []))
     removed = remove_owned(data, commands)
     actions = [f"Removed {removed} exact Kindex legacy handlers (foreign handlers preserved)"]
     plugin = base / "skills" / PLUGIN_NAME

--- a/src/kindex/claude_install.py
+++ b/src/kindex/claude_install.py
@@ -59,36 +59,7 @@ def legacy_manifest(config, kin_path: str) -> dict:
     return {event: [{"matcher": "", "hooks": handlers}] for event, handlers in items.items()}
 
 
-def _historical_kin_paths(data: dict) -> set[str]:
-    """Find candidate old executable paths without treating them as ownership.
-
-    An installation may have moved (or its settings may come from another
-    machine). Decode shell quoting only; the complete command must still match
-    a generated historical template before it can be removed.
-    """
-    paths = set()
-    for entries in data.get("hooks", {}).values():
-        for entry in entries:
-            if not isinstance(entry, dict) or not isinstance(entry.get("hooks"), list):
-                continue
-            for handler in entry["hooks"]:
-                if not isinstance(handler, dict) or handler.get("type") != "command":
-                    continue
-                command = handler.get("command")
-                if not isinstance(command, str):
-                    continue
-                try:
-                    parts = shlex.split(command)
-                    if len(parts) == 3 and parts[:2] == ["/bin/bash", "-lc"]:
-                        parts = shlex.split(parts[2])
-                except ValueError:
-                    continue
-                paths.update(part for part in parts
-                             if Path(part).is_absolute() and Path(part).name == "kin")
-    return paths
-
-
-def _known_commands(config, kin_path, historical_paths=()):
+def _known_commands(config, kin_path):
     from .setup import _kin_hook_command, _kin_stop_hook_command
     commands = {h["command"] for entries in legacy_manifest(config, kin_path).values()
                 for entry in entries for h in entry["hooks"]}
@@ -100,8 +71,10 @@ def _known_commands(config, kin_path, historical_paths=()):
                   "compact-hook", "compact-hook --emit-context", "stop-guard",
                   "attention reinforce --enqueue", "dream --detach --lightweight",
                   'compact-hook --text "Session ended"']
+    # Known prior install locations; never infer ownership from arbitrary paths.
+    historical_binaries = ("/opt/homebrew/bin/kin", "/usr/local/bin/kin")
     for args in historical:
-        for binary in dict.fromkeys(["kin", kin_path, *historical_paths]):
+        for binary in dict.fromkeys(["kin", kin_path, *historical_binaries]):
             commands.add(f"{binary} {args}")
             commands.add(_kin_hook_command(binary, shlex.split(args)))
             commands.add(_kin_stop_hook_command(binary, shlex.split(args)))
@@ -158,8 +131,7 @@ def install(config, *, mode="legacy", dry_run=False, uninstall=False,
     original_data = json.loads(json.dumps(data))
     record = json.loads(record_path.read_text()) if record_path.exists() else {}
     kin_path = _find_kin_path()
-    commands = (_known_commands(config, kin_path, _historical_kin_paths(data))
-                | set(record.get("commands", [])) | set(retire_commands or []))
+    commands = _known_commands(config, kin_path) | set(record.get("commands", [])) | set(retire_commands or [])
     removed = remove_owned(data, commands)
     actions = [f"Removed {removed} exact Kindex legacy handlers (foreign handlers preserved)"]
     plugin = base / "skills" / PLUGIN_NAME

--- a/src/kindex/claude_modern/.claude-plugin/plugin.json
+++ b/src/kindex/claude_modern/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kindex-modern",
-  "version": "0.36.0",
+  "version": "0.36.2",
   "description": "Repo-local Kindex memory and durable tasks for Claude function hooks (qualified on 2.1.263)",
   "author": {"name": "Jeremy McEntire"},
   "homepage": "https://kindex.tools/",

--- a/tests/test_ci_workflow.py
+++ b/tests/test_ci_workflow.py
@@ -1,0 +1,36 @@
+"""The complete test suite gates pull requests and release publication."""
+
+from pathlib import Path
+
+import yaml
+
+
+def test_pr_and_release_share_the_full_test_job():
+    workflow = yaml.load(
+        (Path(__file__).resolve().parents[1] / ".github/workflows/workflow.yml").read_text(),
+        Loader=yaml.BaseLoader,
+    )
+    triggers = workflow["on"]
+    assert "pull_request" in triggers
+    assert triggers["push"]["branches"] == ["main"]
+    assert triggers["push"]["tags"] == ["v*"]
+    assert not triggers["pull_request"]  # No path or activity filters exclude tests.
+    assert "paths" not in triggers["push"]
+    assert "paths-ignore" not in triggers["push"]
+
+    jobs = workflow["jobs"]
+    test = jobs["test"]
+    assert "if" not in test
+    assert "continue-on-error" not in test
+    assert test["runs-on"] == "ubuntu-latest"
+    assert [step["run"] for step in test["steps"] if "run" in step] == [
+        'pip install -e ".[dev,mcp]"', "pytest",
+    ]
+    assert all("continue-on-error" not in step and "if" not in step
+               for step in test["steps"])
+    assert jobs["build"]["needs"] == "test"
+    assert jobs["build"]["if"] == (
+        "github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')"
+    )
+    assert jobs["publish"]["needs"] == "build"
+    assert "if" not in jobs["publish"]

--- a/tests/test_ci_workflow.py
+++ b/tests/test_ci_workflow.py
@@ -6,20 +6,25 @@ import yaml
 
 
 def test_pr_and_release_share_the_full_test_job():
-    workflow = yaml.load(
-        (Path(__file__).resolve().parents[1] / ".github/workflows/workflow.yml").read_text(),
+    workflows = Path(__file__).resolve().parents[1] / ".github/workflows"
+    ci = yaml.load(
+        (workflows / "ci.yml").read_text(),
         Loader=yaml.BaseLoader,
     )
-    triggers = workflow["on"]
-    assert "pull_request" in triggers
-    assert triggers["push"]["branches"] == ["main"]
-    assert triggers["push"]["tags"] == ["v*"]
-    assert not triggers["pull_request"]  # No path or activity filters exclude tests.
-    assert "paths" not in triggers["push"]
-    assert "paths-ignore" not in triggers["push"]
+    release = yaml.load(
+        (workflows / "workflow.yml").read_text(),
+        Loader=yaml.BaseLoader,
+    )
+    assert ci["name"] == "CI"
+    assert ci["on"] == {
+        "pull_request": "", "push": {"branches": ["main"]},
+        "workflow_dispatch": "", "workflow_call": "",
+    }
+    assert release["name"] == "Publish to PyPI"
+    assert release["on"] == {"push": {"tags": ["v*"]}}
 
-    jobs = workflow["jobs"]
-    test = jobs["test"]
+    assert set(ci["jobs"]) == {"test"}
+    test = ci["jobs"]["test"]
     assert "if" not in test
     assert "continue-on-error" not in test
     assert test["runs-on"] == "ubuntu-latest"
@@ -28,9 +33,10 @@ def test_pr_and_release_share_the_full_test_job():
     ]
     assert all("continue-on-error" not in step and "if" not in step
                for step in test["steps"])
-    assert jobs["build"]["needs"] == "test"
-    assert jobs["build"]["if"] == (
-        "github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')"
-    )
+
+    jobs = release["jobs"]
+    assert jobs["ci"] == {"uses": "./.github/workflows/ci.yml"}
+    assert jobs["build"]["needs"] == "ci"
+    assert "if" not in jobs["build"]
     assert jobs["publish"]["needs"] == "build"
     assert "if" not in jobs["publish"]

--- a/tests/test_claude_install.py
+++ b/tests/test_claude_install.py
@@ -65,3 +65,26 @@ def test_idempotent_legacy_install_does_not_rewrite_settings(tmp_path):
     before = settings.stat().st_mtime_ns
     install(cfg)
     assert settings.stat().st_mtime_ns == before
+
+
+@pytest.mark.parametrize("old_path", ["/opt/homebrew/bin/kin", "/usr/local/bin/kin"])
+def test_explicit_historical_location_requires_exact_command(old_path):
+    from kindex.claude_install import _known_commands
+    from kindex.setup import _kin_stop_hook_command
+
+    known = _known_commands(Config(), "/current/bin/kin")
+    command = _kin_stop_hook_command(old_path, ["compact-hook", "--text", "Session ended"])
+    assert command in known
+    assert command.replace("\n", "\\n") in known
+    assert command + "; custom-audit" not in known
+    assert command.replace("then exit 0", "then exit 7") not in known
+
+
+@pytest.mark.parametrize("unknown_path", ["/custom/bin/kin", "/custom tools/bin/kin"])
+def test_custom_kin_location_is_not_implicitly_owned(unknown_path):
+    from kindex.claude_install import _known_commands
+    from kindex.setup import _kin_stop_hook_command
+
+    command = _kin_stop_hook_command(unknown_path, ["compact-hook", "--text", "Session ended"])
+    assert command not in _known_commands(Config(), "/current/bin/kin")
+    assert command in _known_commands(Config(), unknown_path)

--- a/tests/test_release_metadata.py
+++ b/tests/test_release_metadata.py
@@ -38,6 +38,11 @@ def test_version_is_consistent_across_release_surfaces():
     assert registry["version"] == version
     assert registry["packages"][0]["version"] == version
     assert card["serverInfo"]["version"] == version
+    for manifest in (
+        ".claude-plugin/plugin.json",
+        "src/kindex/claude_modern/.claude-plugin/plugin.json",
+    ):
+        assert json.loads((ROOT / manifest).read_text())["version"] == version
     assert f"version-{version}-purple" in readme
     assert f"v{version}" in docs
     assert re.search(rf"^## \[{re.escape(version)}\]", changelog, re.MULTILINE)


### PR DESCRIPTION
Prepare 0.36.2 after the failed v0.36.1 release attempt. Claude hook migration did not recognize an old absolute `kin` executable path, leaving the obsolete `compact-hook --text` handler installed. PR #23 had already reported the same failure on unchanged main, but pytest ran automatically only on release tags, so it was not a PR check.

Support the two explicit historical executable locations `/opt/homebrew/bin/kin` and `/usr/local/bin/kin` alongside bare `kin` and the current executable. Removal still requires an exact complete-command match, preserving foreign handlers and entry metadata. Other locations require recorded installer ownership or explicit retirement.

The separate `CI` workflow owns full pytest with Python 3.12 and `.[dev,mcp]`. It runs on PRs/main pushes, supports manual dispatch, and exposes `workflow_call`. `Publish to PyPI` triggers only on v* tags and calls the same CI workflow before building and publishing. Add a workflow regression test, point the README badge at CI, and document the invariant in CLAUDE.md and project memory.

Align package/runtime version, both Claude plugin manifests, MCP registry and server card, public badges, and changelog at **0.36.2**. Extend the release consistency test to cover both plugin manifests.

Validation:
- Original migration regression fails against unchanged release source 8fe3225 and passes with this fix.
- Focused migration/setup/workflow suite: 65 passed, including the newly added workflow test and four explicit-location matching cases.
- The two new supported-location tests fail against unchanged release source and pass with this fix. Matching tests also reject custom locations, appended commands, and changed recursion guards.
- Workflow regression test checks automatic/manual/reusable CI triggers, full pytest execution, tag-only release triggering, and the CI→build→publish dependency chain. Workflow and metadata checks pass (6 tests); `actionlint` 1.7.12 passes for both workflows.
- Full local suite before the metadata-only bump: **2,166 passed, 1 skipped**, using a macOS sandbox denying network, host-home writes, and scheduler execution. After the bump, all **15 metadata, installer, and workflow tests passed**.
- Built `kindex-0.36.2.tar.gz` and `kindex-0.36.2-py3-none-any.whl`. Installed the wheel with its MCP extra into a fresh venv; CLI, runtime version, distribution metadata, and MCP import verified at 0.36.2.
- Independent code/workflow review: no actionable findings. Final `CI / test` passed **2,166 tests, 1 skipped** at `a187327` in [run 34547640183](https://github.com/wandercom/kindex/actions/runs/34547640183). Fresh Bugbot passed. The tag-only publishing workflow did not run on the PR.

Repository main currently has no branch protection or rulesets. This adds the CI check; requiring it before merge is a separate repository setting. No release tag is created or moved. Once merged, the prepared package version is ready for a fresh v0.36.2 release tag per CLAUDE.md.
